### PR TITLE
LPS-74301 Store parameters in request body to avoid 414 (Request-URI Too Long) error caused by many calendarIds

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/js/remote_services.js
@@ -106,7 +106,7 @@ AUI.add(
 					instance._invokeResourceURL(
 						{
 							callback: callback,
-							queryParameters: {
+							payload: {
 								calendarIds: calendarIds.join(),
 								endTime: endDate.getTime(),
 								ruleName: ruleName,
@@ -152,7 +152,7 @@ AUI.add(
 					instance._invokeResourceURL(
 						{
 							callback: callback,
-							queryParameters: {
+							payload: {
 								calendarIds: calendarIds.join(','),
 								endTimeDay: endDate.getDate(),
 								endTimeHour: endDate.getHours(),


### PR DESCRIPTION
Hey @natocesarrego,

Here's an updated fix based on your recommendation here: https://github.com/natocesarrego/liferay-portal/pull/90#discussion_r135327529

The request was already a POST, I just had to put the parameters in the body (payload) rather than in the URL (queryParameters).

Please let me know if you have any questions, and thank you again for your help with this!

https://issues.liferay.com/browse/LPS-74301

/cc @brandizzi