### PR TITLE
J cords lps 74454 revised 3

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/notification/NotificationTemplateType.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/notification/NotificationTemplateType.java
@@ -20,8 +20,8 @@ package com.liferay.calendar.notification;
  */
 public enum NotificationTemplateType {
 
-	DECLINE("decline"), INVITE("invite"), MOVED_TO_TRASH("moved-to-trash"),
-	REMINDER("reminder"), UPDATE("update");
+	DECLINE("decline"), INVITE("invite"), INSTANCE_DELETED("instance-deleted"),
+	MOVED_TO_TRASH("moved-to-trash"), REMINDER("reminder"), UPDATE("update");
 
 	public static NotificationTemplateType parse(String value) {
 		if (DECLINE.getValue().equals(value)) {
@@ -29,6 +29,9 @@ public enum NotificationTemplateType {
 		}
 		else if (INVITE.getValue().equals(value)) {
 			return INVITE;
+		}
+		else if (INSTANCE_DELETED.getValue().equals(value)) {
+			return INSTANCE_DELETED;
 		}
 		else if (MOVED_TO_TRASH.getValue().equals(value)) {
 			return MOVED_TO_TRASH;

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalService.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalService.java
@@ -147,22 +147,70 @@ public interface CalendarBookingLocalService extends BaseLocalService,
 	public CalendarBooking deleteCalendarBooking(long calendarBookingId,
 		boolean allRecurringInstances) throws PortalException;
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, int, boolean)}
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing) throws PortalException;
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, int, boolean,
+	boolean)}
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing,
 		boolean deleteRecurringCalendarBookings) throws PortalException;
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, long, boolean)}
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing) throws PortalException;
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, long, boolean,
+	boolean)}
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing,
 		boolean deleteRecurringCalendarBookings) throws PortalException;
 
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, int instanceIndex, boolean allFollowing)
+		throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, int instanceIndex,
+		boolean allFollowing, boolean deleteRecurringCalendarBookings)
+		throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, long startTime, boolean allFollowing)
+		throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, long startTime, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings) throws PortalException;
+
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, long, long, boolean)}
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(long calendarBookingId,
 		long startTime, boolean allFollowing) throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		long calendarBookingId, long startTime, boolean allFollowing)
+		throws PortalException;
 
 	public void deleteCalendarBookings(long calendarId)
 		throws PortalException;

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceUtil.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceUtil.java
@@ -155,6 +155,11 @@ public class CalendarBookingLocalServiceUtil {
 			allRecurringInstances);
 	}
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, int, boolean)}
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing)
@@ -164,6 +169,12 @@ public class CalendarBookingLocalServiceUtil {
 			allFollowing);
 	}
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, int, boolean,
+	boolean)}
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing,
@@ -174,6 +185,11 @@ public class CalendarBookingLocalServiceUtil {
 			allFollowing, deleteRecurringCalendarBookings);
 	}
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, long, boolean)}
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing)
@@ -183,6 +199,12 @@ public class CalendarBookingLocalServiceUtil {
 			allFollowing);
 	}
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, long, boolean,
+	boolean)}
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing,
@@ -193,12 +215,63 @@ public class CalendarBookingLocalServiceUtil {
 			allFollowing, deleteRecurringCalendarBookings);
 	}
 
+	public static void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		int instanceIndex, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBooking,
+			instanceIndex, allFollowing);
+	}
+
+	public static void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		int instanceIndex, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBooking,
+			instanceIndex, allFollowing, deleteRecurringCalendarBookings);
+	}
+
+	public static void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		long startTime, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBooking, startTime,
+			allFollowing);
+	}
+
+	public static void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		long startTime, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBooking, startTime,
+			allFollowing, deleteRecurringCalendarBookings);
+	}
+
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, long, long, boolean)}
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(long calendarBookingId,
 		long startTime, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		getService()
 			.deleteCalendarBookingInstance(calendarBookingId, startTime,
 			allFollowing);
+	}
+
+	public static void deleteCalendarBookingInstance(long userId,
+		long calendarBookingId, long startTime, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBookingId,
+			startTime, allFollowing);
 	}
 
 	public static void deleteCalendarBookings(long calendarId)

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceWrapper.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceWrapper.java
@@ -154,6 +154,11 @@ public class CalendarBookingLocalServiceWrapper
 			allRecurringInstances);
 	}
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, int, boolean)}
+	*/
+	@Deprecated
 	@Override
 	public void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
@@ -163,6 +168,12 @@ public class CalendarBookingLocalServiceWrapper
 			instanceIndex, allFollowing);
 	}
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, int, boolean,
+	boolean)}
+	*/
+	@Deprecated
 	@Override
 	public void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
@@ -173,6 +184,11 @@ public class CalendarBookingLocalServiceWrapper
 			instanceIndex, allFollowing, deleteRecurringCalendarBookings);
 	}
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, long, boolean)}
+	*/
+	@Deprecated
 	@Override
 	public void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
@@ -182,6 +198,12 @@ public class CalendarBookingLocalServiceWrapper
 			startTime, allFollowing);
 	}
 
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, CalendarBooking, long, boolean,
+	boolean)}
+	*/
+	@Deprecated
 	@Override
 	public void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
@@ -193,11 +215,64 @@ public class CalendarBookingLocalServiceWrapper
 	}
 
 	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		int instanceIndex, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, instanceIndex, allFollowing);
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		int instanceIndex, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, instanceIndex, allFollowing,
+			deleteRecurringCalendarBookings);
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		long startTime, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, startTime, allFollowing);
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		long startTime, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, startTime, allFollowing,
+			deleteRecurringCalendarBookings);
+	}
+
+	/**
+	* @deprecated As of 3.0.0, replaced by {@link
+	#deleteCalendarBookingInstance(long, long, long, boolean)}
+	*/
+	@Deprecated
+	@Override
 	public void deleteCalendarBookingInstance(long calendarBookingId,
 		long startTime, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		_calendarBookingLocalService.deleteCalendarBookingInstance(calendarBookingId,
 			startTime, allFollowing);
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		long calendarBookingId, long startTime, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBookingId, startTime, allFollowing);
 	}
 
 	@Override

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/notification/impl/NotificationTemplateContextFactory.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/notification/impl/NotificationTemplateContextFactory.java
@@ -32,10 +32,12 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.Serializable;
 
@@ -57,7 +59,8 @@ public class NotificationTemplateContextFactory {
 	public static NotificationTemplateContext getInstance(
 			NotificationType notificationType,
 			NotificationTemplateType notificationTemplateType,
-			CalendarBooking calendarBooking, User user)
+			CalendarBooking calendarBooking, User user,
+			ServiceContext serviceContext)
 		throws Exception {
 
 		CalendarBooking parentCalendarBooking =
@@ -138,6 +141,21 @@ public class NotificationTemplateContextFactory {
 			user, calendarBooking.getCalendarBookingId());
 
 		attributes.put("url", calendarBookingURL);
+
+		if (Validator.isNotNull(serviceContext)) {
+			if (Validator.isNotNull(
+					serviceContext.getAttribute("instanceStartTime"))) {
+
+				long instanceStartTimeL = (long)serviceContext.getAttribute(
+					"instanceStartTime");
+
+				String instanceStartTime =
+					dateFormatDateTime.format(instanceStartTimeL) +
+						StringPool.SPACE + userTimezoneDisplayName;
+
+				attributes.put("instanceStartTime", instanceStartTime);
+			}
+		}
 
 		notificationTemplateContext.setAttributes(attributes);
 

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/notification/impl/NotificationTemplateRenderer.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/notification/impl/NotificationTemplateRenderer.java
@@ -63,8 +63,9 @@ public class NotificationTemplateRenderer {
 			new String[] {
 				"[$EVENT_END_DATE$]", "[$EVENT_LOCATION$]",
 				"[$EVENT_START_DATE$]", "[$EVENT_TITLE$]", "[$EVENT_URL$]",
-				"[$FROM_ADDRESS$]", "[$FROM_NAME$]", "[$PORTAL_URL$]",
-				"[$PORTLET_NAME$]", "[$TO_ADDRESS$]", "[$TO_NAME$]"
+				"[$INSTANCE_START_TIME$]", "[$FROM_ADDRESS$]", "[$FROM_NAME$]",
+				"[$PORTAL_URL$]", "[$PORTLET_NAME$]", "[$TO_ADDRESS$]",
+				"[$TO_NAME$]"
 			},
 			new String[] {
 				GetterUtil.getString(attributes.get("endTime")),
@@ -73,6 +74,7 @@ public class NotificationTemplateRenderer {
 				GetterUtil.getString(attributes.get("startTime")),
 				HtmlUtil.escape(GetterUtil.getString(attributes.get("title"))),
 				GetterUtil.getString(attributes.get("url")),
+				GetterUtil.getString(attributes.get("instanceStartTime")),
 				GetterUtil.getString(
 					notificationTemplateContext.getFromAddress()),
 				GetterUtil.getString(notificationTemplateContext.getFromName()),

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/notification/impl/NotificationUtil.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/notification/impl/NotificationUtil.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Time;
@@ -128,7 +129,8 @@ public class NotificationUtil {
 
 	public static void notifyCalendarBookingRecipients(
 			CalendarBooking calendarBooking, NotificationType notificationType,
-			NotificationTemplateType notificationTemplateType, User senderUser)
+			NotificationTemplateType notificationTemplateType, User senderUser,
+			ServiceContext serviceContext)
 		throws Exception {
 
 		NotificationSender notificationSender =
@@ -151,7 +153,7 @@ public class NotificationUtil {
 			NotificationTemplateContext notificationTemplateContext =
 				NotificationTemplateContextFactory.getInstance(
 					notificationType, notificationTemplateType, calendarBooking,
-					recipientUser);
+					recipientUser, serviceContext);
 
 			notificationSender.sendNotification(
 				senderUser.getEmailAddress(), resourceName,
@@ -173,7 +175,7 @@ public class NotificationUtil {
 				NotificationTemplateContext notificationTemplateContext =
 					NotificationTemplateContextFactory.getInstance(
 						notificationType, notificationTemplateType,
-						calendarBooking, user);
+						calendarBooking, user, serviceContext);
 
 				notificationSender.sendNotification(
 					senderUser.getEmailAddress(), senderUser.getFullName(),
@@ -228,7 +230,7 @@ public class NotificationUtil {
 			NotificationTemplateContext notificationTemplateContext =
 				NotificationTemplateContextFactory.getInstance(
 					notificationType, NotificationTemplateType.REMINDER,
-					calendarBooking, user);
+					calendarBooking, user, null);
 
 			notificationSender.sendNotification(
 				user.getEmailAddress(), user.getFullName(),

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -580,6 +580,18 @@ public class CalendarBookingLocalServiceImpl
 				recurrenceObj.setCount(0);
 			}
 
+			int instanceIndex = RecurrenceUtil.getIndexOfInstance(
+				calendarBooking.getRecurrence(), calendarBooking.getStartTime(),
+				startTime);
+
+			CalendarBooking calendarBookingInstance =
+				RecurrenceUtil.getCalendarBookingInstance(
+					calendarBooking, instanceIndex + 1);
+
+			if (calendarBookingInstance != null) {
+				notificationTemplateType = NotificationTemplateType.UPDATE;
+			}
+
 			startTimeJCalendar.add(java.util.Calendar.DATE, -1);
 
 			recurrenceObj.setUntilJCalendar(startTimeJCalendar);

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -541,6 +541,8 @@ public class CalendarBookingLocalServiceImpl
 		throws PortalException {
 
 		Date now = new Date();
+		NotificationTemplateType notificationTemplateType =
+			NotificationTemplateType.INSTANCE_DELETED;
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setUserId(userId);
@@ -604,9 +606,10 @@ public class CalendarBookingLocalServiceImpl
 
 		updateChildCalendarBookings(calendarBooking, now, recurrence);
 
+		serviceContext.setAttribute("instanceStartTime", startTime);
+
 		_sendChildrenNotifications(
-			calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
-			serviceContext);
+			calendarBooking, notificationTemplateType, serviceContext);
 	}
 
 	/**
@@ -2084,7 +2087,7 @@ public class CalendarBookingLocalServiceImpl
 
 			NotificationUtil.notifyCalendarBookingRecipients(
 				calendarBooking, notificationType, notificationTemplateType,
-				sender);
+				sender, serviceContext);
 		}
 		catch (Exception e) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -448,9 +448,55 @@ public class CalendarBookingLocalServiceImpl
 		return calendarBooking;
 	}
 
-	@Override
+	/**
+	 * @deprecated As of 3.0.0, replaced by {@link
+	 * #deleteCalendarBookingInstance(long, CalendarBooking, int, boolean)}
+	 */
+	@Deprecated
 	public void deleteCalendarBookingInstance(
 			CalendarBooking calendarBooking, int instanceIndex,
+			boolean allFollowing)
+		throws PortalException {
+	}
+
+	/**
+	 * @deprecated As of 3.0.0, replaced by {@link
+	 * #deleteCalendarBookingInstance(long, CalendarBooking, int, boolean,
+	 * boolean)}
+	 */
+	@Deprecated
+	public void deleteCalendarBookingInstance(
+			CalendarBooking calendarBooking, int instanceIndex,
+			boolean allFollowing, boolean deleteRecurringCalendarBookings)
+		throws PortalException {
+	}
+
+	/**
+	 * @deprecated As of 3.0.0, replaced by {@link
+	 * #deleteCalendarBookingInstance(long, CalendarBooking, long, boolean)}
+	 */
+	@Deprecated
+	public void deleteCalendarBookingInstance(
+			CalendarBooking calendarBooking, long startTime,
+			boolean allFollowing)
+		throws PortalException {
+	}
+
+	/**
+	 * @deprecated As of 3.0.0, replaced by {@link
+	 * #deleteCalendarBookingInstance(long, CalendarBooking, long, boolean,
+	 * boolean)}
+	 */
+	@Deprecated
+	public void deleteCalendarBookingInstance(
+			CalendarBooking calendarBooking, long startTime,
+			boolean allFollowing, boolean deleteRecurringCalendarBookings)
+		throws PortalException {
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(
+			long userId, CalendarBooking calendarBooking, int instanceIndex,
 			boolean allFollowing)
 		throws PortalException {
 
@@ -459,13 +505,13 @@ public class CalendarBookingLocalServiceImpl
 				calendarBooking, instanceIndex);
 
 		deleteCalendarBookingInstance(
-			calendarBooking, calendarBookingInstance.getStartTime(),
+			userId, calendarBooking, calendarBookingInstance.getStartTime(),
 			allFollowing);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, int instanceIndex,
+			long userId, CalendarBooking calendarBooking, int instanceIndex,
 			boolean allFollowing, boolean deleteRecurringCalendarBookings)
 		throws PortalException {
 
@@ -474,23 +520,23 @@ public class CalendarBookingLocalServiceImpl
 				calendarBooking, instanceIndex);
 
 		deleteCalendarBookingInstance(
-			calendarBooking, calendarBookingInstance.getStartTime(),
+			userId, calendarBooking, calendarBookingInstance.getStartTime(),
 			allFollowing, deleteRecurringCalendarBookings);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, long startTime,
+			long userId, CalendarBooking calendarBooking, long startTime,
 			boolean allFollowing)
 		throws PortalException {
 
 		deleteCalendarBookingInstance(
-			calendarBooking, startTime, allFollowing, false);
+			userId, calendarBooking, startTime, allFollowing, false);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, long startTime,
+			long userId, CalendarBooking calendarBooking, long startTime,
 			boolean allFollowing, boolean deleteRecurringCalendarBookings)
 		throws PortalException {
 
@@ -504,7 +550,8 @@ public class CalendarBookingLocalServiceImpl
 		if (allFollowing) {
 			if (deleteRecurringCalendarBookings) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(calendarBooking, startTime);
+					splitCalendarBookingInstances(
+						userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -547,15 +594,27 @@ public class CalendarBookingLocalServiceImpl
 		updateChildCalendarBookings(calendarBooking, now, recurrence);
 	}
 
-	@Override
+	/**
+	 * @deprecated As of 3.0.0, replaced by {@link
+	 * #deleteCalendarBookingInstance(long, long, long, boolean)}
+	 */
+	@Deprecated
 	public void deleteCalendarBookingInstance(
 			long calendarBookingId, long startTime, boolean allFollowing)
+		throws PortalException {
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(
+			long userId, long calendarBookingId, long startTime,
+			boolean allFollowing)
 		throws PortalException {
 
 		CalendarBooking calendarBooking =
 			calendarBookingPersistence.findByPrimaryKey(calendarBookingId);
 
-		deleteCalendarBookingInstance(calendarBooking, startTime, allFollowing);
+		deleteCalendarBookingInstance(
+			userId, calendarBooking, startTime, allFollowing);
 	}
 
 	@Override
@@ -832,7 +891,8 @@ public class CalendarBookingLocalServiceImpl
 
 			if (allFollowing) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(calendarBooking, startTime);
+					splitCalendarBookingInstances(
+						userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -860,7 +920,7 @@ public class CalendarBookingLocalServiceImpl
 			}
 
 			deleteCalendarBookingInstance(
-				calendarBooking, startTime, allFollowing);
+				userId, calendarBooking, startTime, allFollowing);
 
 			calendarBooking = addCalendarBooking(
 				userId, calendarId, childCalendarIds, 0,
@@ -1330,7 +1390,7 @@ public class CalendarBookingLocalServiceImpl
 		String oldRecurrence = calendarBooking.getRecurrence();
 
 		deleteCalendarBookingInstance(
-			calendarBooking, instanceIndex, allFollowing, false);
+			userId, calendarBooking, instanceIndex, allFollowing, false);
 
 		Map<Locale, String> updatedTitleMap = calendarBooking.getTitleMap();
 
@@ -1345,7 +1405,8 @@ public class CalendarBookingLocalServiceImpl
 			Calendar calendar = calendarLocalService.getCalendar(calendarId);
 
 			List<CalendarBooking> recurringCalendarBookings =
-				splitCalendarBookingInstances(calendarBooking, startTime);
+				splitCalendarBookingInstances(
+					userId, calendarBooking, startTime);
 
 			List<String> unmodifiedAttributesNames =
 				getUnmodifiedAttributesNames(
@@ -2018,7 +2079,7 @@ public class CalendarBookingLocalServiceImpl
 	}
 
 	protected CalendarBooking splitCalendarBookingInstance(
-			CalendarBooking calendarBooking, long startTime,
+			long userId, CalendarBooking calendarBooking, long startTime,
 			Recurrence recurrence)
 		throws PortalException {
 
@@ -2046,13 +2107,14 @@ public class CalendarBookingLocalServiceImpl
 			calendarBooking.getSecondReminderType(),
 			ServiceContextThreadLocal.getServiceContext());
 
-		deleteCalendarBookingInstance(calendarBooking, startTime, true, false);
+		deleteCalendarBookingInstance(
+			userId, calendarBooking, startTime, true, false);
 
 		return calendarBookingInstance;
 	}
 
 	protected List<CalendarBooking> splitCalendarBookingInstances(
-			CalendarBooking calendarBooking, long startTime)
+			long userId, CalendarBooking calendarBooking, long startTime)
 		throws PortalException {
 
 		List<CalendarBooking> recurringCalendarBookings =
@@ -2105,7 +2167,7 @@ public class CalendarBookingLocalServiceImpl
 
 						CalendarBooking newCalendarBooking =
 							splitCalendarBookingInstance(
-								recurringCalendarBooking,
+								userId, recurringCalendarBooking,
 								newStartTimeJCalendar.getTimeInMillis(),
 								recurrenceSplit.getSecondRecurrence());
 

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -541,6 +541,9 @@ public class CalendarBookingLocalServiceImpl
 		throws PortalException {
 
 		Date now = new Date();
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setUserId(userId);
 
 		java.util.Calendar startTimeJCalendar = JCalendarUtil.getJCalendar(
 			startTime, calendarBooking.getTimeZone());
@@ -561,6 +564,10 @@ public class CalendarBookingLocalServiceImpl
 			}
 
 			if (startTime == calendarBooking.getStartTime()) {
+				_sendChildrenNotifications(
+					calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
+					serviceContext);
+
 				calendarBookingLocalService.deleteCalendarBooking(
 					calendarBooking, false);
 
@@ -580,6 +587,10 @@ public class CalendarBookingLocalServiceImpl
 				RecurrenceUtil.getCalendarBookingInstance(calendarBooking, 1);
 
 			if (calendarBookingInstance == null) {
+				_sendChildrenNotifications(
+					calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
+					serviceContext);
+
 				calendarBookingLocalService.deleteCalendarBooking(
 					calendarBooking, false);
 
@@ -592,6 +603,10 @@ public class CalendarBookingLocalServiceImpl
 		String recurrence = RecurrenceSerializer.serialize(recurrenceObj);
 
 		updateChildCalendarBookings(calendarBooking, now, recurrence);
+
+		_sendChildrenNotifications(
+			calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
+			serviceContext);
 	}
 
 	/**
@@ -2311,6 +2326,27 @@ public class CalendarBookingLocalServiceImpl
 
 	@ServiceReference(type = TrashEntryLocalService.class)
 	protected TrashEntryLocalService trashEntryLocalService;
+
+	private void _sendChildrenNotifications(
+		CalendarBooking calendarBooking,
+		NotificationTemplateType notificationType,
+		ServiceContext serviceContext) {
+
+		List<CalendarBooking> childCalendarBookings =
+			calendarBooking.getChildCalendarBookings();
+
+		for (CalendarBooking childCalendarBooking : childCalendarBookings) {
+			if (childCalendarBooking.equals(calendarBooking)) {
+				continue;
+			}
+
+			sendNotification(
+				childCalendarBooking, notificationType, serviceContext);
+
+			_sendChildrenNotifications(
+				childCalendarBooking, notificationType, serviceContext);
+		}
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CalendarBookingLocalServiceImpl.class);

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
@@ -203,7 +203,7 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
-			calendarBooking, instanceIndex, allFollowing);
+			getUserId(), calendarBooking, instanceIndex, allFollowing);
 	}
 
 	@Override
@@ -220,7 +220,7 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
-			calendarBooking, instanceIndex, allFollowing,
+			getUserId(), calendarBooking, instanceIndex, allFollowing,
 			deleteRecurringCalendarBookings);
 	}
 
@@ -237,7 +237,7 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
-			calendarBookingId, startTime, allFollowing);
+			getUserId(), calendarBookingId, startTime, allFollowing);
 	}
 
 	@Override

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/notification/impl/packageinfo
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/notification/impl/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_instance_deleted_body.tmpl
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_instance_deleted_body.tmpl
@@ -1,0 +1,8 @@
+[$TO_NAME$],<br /><br />
+
+The event <a href="[$EVENT_URL$]">[$EVENT_TITLE$]</a>, that you were invited to starting on <strong>[$INSTANCE_START_TIME$]</strong>, was deleted.<br /><br />
+
+Sincerely,<br />
+[$FROM_NAME$]<br />
+[$FROM_ADDRESS$]<br />
+[$PORTAL_URL$]

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_instance_deleted_subject.tmpl
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/service/configuration/dependencies/email/booking_instance_deleted_subject.tmpl
@@ -1,0 +1,1 @@
+[$PORTLET_NAME$]: Event Deletion for "[$EVENT_TITLE$]"

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/service/configuration/dependencies/im/booking_instance_deleted_body.tmpl
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/service/configuration/dependencies/im/booking_instance_deleted_body.tmpl
@@ -1,0 +1,3 @@
+The event [$EVENT_TITLE$], that you were invited to starting on <strong>[$INSTANCE_START_TIME$]</strong>, was deleted.
+
+Sincerely, [$FROM_NAME$].

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/service/configuration/dependencies/im/booking_instance_deleted_subject.tmpl
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/com/liferay/calendar/service/configuration/dependencies/im/booking_instance_deleted_subject.tmpl
@@ -1,0 +1,1 @@
+Event Deletion

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/portlet.properties
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/portlet.properties
@@ -6,12 +6,14 @@ calendar.color.default=0xD96666
 
 calendar.notification.body[email][invite]=com/liferay/calendar/service/configuration/dependencies/email/booking_invite_body.tmpl
 calendar.notification.body[email][decline]=com/liferay/calendar/service/configuration/dependencies/email/booking_decline_body.tmpl
+calendar.notification.body[email][instance-deleted]=com/liferay/calendar/service/configuration/dependencies/email/booking_instance_deleted_body.tmpl
 calendar.notification.body[email][moved-to-trash]=com/liferay/calendar/service/configuration/dependencies/email/booking_moved_to_trash_body.tmpl
 calendar.notification.body[email][reminder]=com/liferay/calendar/service/configuration/dependencies/email/booking_reminder_body.tmpl
 calendar.notification.body[email][update]=com/liferay/calendar/service/configuration/dependencies/email/booking_update_body.tmpl
 
 calendar.notification.body[im][invite]=com/liferay/calendar/service/configuration/dependencies/im/booking_invite_body.tmpl
 calendar.notification.body[im][decline]=com/liferay/calendar/service/configuration/dependencies/im/booking_invite_body.tmpl
+calendar.notification.body[im][instance-deleted]=com/liferay/calendar/service/configuration/dependencies/im/booking_instance_deleted_body.tmpl
 calendar.notification.body[im][moved-to-trash]=com/liferay/calendar/service/configuration/dependencies/im/booking_moved_to_trash_body.tmpl
 calendar.notification.body[im][reminder]=com/liferay/calendar/service/configuration/dependencies/im/booking_reminder_body.tmpl
 
@@ -32,12 +34,14 @@ calendar.notification.enabled[im][reminder]=true
 
 calendar.notification.subject[email][invite]=com/liferay/calendar/service/configuration/dependencies/email/booking_invite_subject.tmpl
 calendar.notification.subject[email][decline]=com/liferay/calendar/service/configuration/dependencies/email/booking_decline_subject.tmpl
+calendar.notification.subject[email][instance-deleted]=com/liferay/calendar/service/configuration/dependencies/email/booking_instance_deleted_subject.tmpl
 calendar.notification.subject[email][moved-to-trash]=com/liferay/calendar/service/configuration/dependencies/email/booking_moved_to_trash_subject.tmpl
 calendar.notification.subject[email][reminder]=com/liferay/calendar/service/configuration/dependencies/email/booking_reminder_subject.tmpl
 calendar.notification.subject[email][update]=com/liferay/calendar/service/configuration/dependencies/email/booking_update_subject.tmpl
 
 calendar.notification.subject[im][invite]=com/liferay/calendar/service/configuration/dependencies/im/booking_invite_subject.tmpl
 calendar.notification.subject[im][decline]=com/liferay/calendar/service/configuration/dependencies/im/booking_decline_subject.tmpl
+calendar.notification.subject[im][instance-deleted]=com/liferay/calendar/service/configuration/dependencies/im/booking_instance_deleted_subject.tmpl
 calendar.notification.subject[im][moved-to-trash]=com/liferay/calendar/service/configuration/dependencies/im/booking_moved_to_trash_subject.tmpl
 calendar.notification.subject[im][reminder]=com/liferay/calendar/service/configuration/dependencies/im/booking_reminder_subject.tmpl
 

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
@@ -30,6 +30,7 @@ import com.liferay.calendar.test.util.CalendarTestUtil;
 import com.liferay.calendar.test.util.CheckBookingsMessageListenerTestUtil;
 import com.liferay.calendar.test.util.RecurrenceTestUtil;
 import com.liferay.calendar.util.JCalendarUtil;
+import com.liferay.calendar.util.RecurrenceUtil;
 import com.liferay.calendar.workflow.CalendarBookingWorkflowConstants;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -578,12 +579,16 @@ public class CalendarBookingLocalServiceTest {
 		CalendarBooking calendarBooking =
 			CalendarBookingTestUtil.addRecurringCalendarBooking(
 				invitingcalendar, invitedCalendar,
-				RecurrenceTestUtil.getDailyRecurrence(2), serviceContext);
+				RecurrenceTestUtil.getDailyRecurrence(5), serviceContext);
 
 		long calendarBookingId = calendarBooking.getCalendarBookingId();
 
+		CalendarBooking calendarBookingInstance =
+			RecurrenceUtil.getCalendarBookingInstance(calendarBooking, 3);
+
 		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
-			_invitingUser.getUserId(), calendarBooking, 0, false);
+			_invitingUser.getUserId(), calendarBooking,
+			calendarBookingInstance.getStartTime(), true, false);
 
 		calendarBooking = CalendarBookingLocalServiceUtil.fetchCalendarBooking(
 			calendarBookingId);
@@ -591,7 +596,7 @@ public class CalendarBookingLocalServiceTest {
 		Assert.assertNotNull(calendarBooking);
 
 		String mailMessageSubject =
-			"Calendar: Event Deletion for " + StringPool.QUOTE +
+			"Calendar: Event Update for " + StringPool.QUOTE +
 				calendarBooking.getTitle(LocaleUtil.getDefault()) +
 					StringPool.QUOTE;
 
@@ -599,6 +604,27 @@ public class CalendarBookingLocalServiceTest {
 			"Subject", mailMessageSubject);
 
 		Assert.assertEquals(mailMessages.toString(), 1, mailMessages.size());
+
+		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
+			_invitingUser.getUserId(), calendarBooking, 2, true);
+
+		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
+			_invitingUser.getUserId(), calendarBooking, 1, false);
+
+		calendarBooking = CalendarBookingLocalServiceUtil.fetchCalendarBooking(
+			calendarBookingId);
+
+		Assert.assertNotNull(calendarBooking);
+
+		mailMessageSubject =
+			"Calendar: Event Deletion for " + StringPool.QUOTE +
+				calendarBooking.getTitle(LocaleUtil.getDefault()) +
+					StringPool.QUOTE;
+
+		mailMessages = MailServiceTestUtil.getMailMessages(
+			"Subject", mailMessageSubject);
+
+		Assert.assertEquals(mailMessages.toString(), 2, mailMessages.size());
 
 		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
 			_user.getUserId(), calendarBooking, 0, false);

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
@@ -564,6 +564,52 @@ public class CalendarBookingLocalServiceTest {
 	}
 
 	@Test
+	public void testDeleteCalendarBookingRecurringInstanceNotifiesInvitees()
+		throws Exception {
+
+		ServiceContext serviceContext = createServiceContext();
+
+		_invitingUser = UserTestUtil.addUser();
+
+		Calendar invitingcalendar = CalendarTestUtil.addCalendar(_invitingUser);
+
+		Calendar invitedCalendar = CalendarTestUtil.addCalendar(_user);
+
+		CalendarBooking calendarBooking =
+			CalendarBookingTestUtil.addRecurringCalendarBooking(
+				invitingcalendar, invitedCalendar,
+				RecurrenceTestUtil.getDailyRecurrence(2), serviceContext);
+
+		long calendarBookingId = calendarBooking.getCalendarBookingId();
+
+		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
+			_invitingUser.getUserId(), calendarBooking, 0, false);
+
+		calendarBooking = CalendarBookingLocalServiceUtil.fetchCalendarBooking(
+			calendarBookingId);
+
+		Assert.assertNotNull(calendarBooking);
+
+		String mailMessageSubject =
+			"Calendar: Event Deletion for " + StringPool.QUOTE +
+				calendarBooking.getTitle(LocaleUtil.getDefault()) +
+					StringPool.QUOTE;
+
+		List<MailMessage> mailMessages = MailServiceTestUtil.getMailMessages(
+			"Subject", mailMessageSubject);
+
+		Assert.assertEquals(mailMessages.toString(), 1, mailMessages.size());
+
+		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
+			_user.getUserId(), calendarBooking, 0, false);
+
+		calendarBooking = CalendarBookingLocalServiceUtil.fetchCalendarBooking(
+			calendarBookingId);
+
+		Assert.assertNull(calendarBooking);
+	}
+
+	@Test
 	public void testDeleteCalendarBookingWithAllFollowingInstances()
 		throws Exception {
 

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
@@ -580,7 +580,7 @@ public class CalendarBookingLocalServiceTest {
 				calendarBooking, 2, titleMap, serviceContext);
 
 		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
-			calendarBooking, 1, true, true);
+			_user.getUserId(), calendarBooking, 1, true, true);
 
 		calendarBookingInstance =
 			CalendarBookingLocalServiceUtil.fetchCalendarBooking(
@@ -658,7 +658,7 @@ public class CalendarBookingLocalServiceTest {
 		long calendarBookingId = calendarBooking.getCalendarBookingId();
 
 		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
-			calendarBooking, 0, false);
+			_user.getUserId(), calendarBooking, 0, false);
 
 		calendarBooking = CalendarBookingLocalServiceUtil.fetchCalendarBooking(
 			calendarBookingId);
@@ -666,7 +666,7 @@ public class CalendarBookingLocalServiceTest {
 		Assert.assertNotNull(calendarBooking);
 
 		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
-			calendarBooking, 0, false);
+			_user.getUserId(), calendarBooking, 0, false);
 
 		calendarBooking = CalendarBookingLocalServiceUtil.fetchCalendarBooking(
 			calendarBookingId);

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/test/util/CalendarBookingTestUtil.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/test/util/CalendarBookingTestUtil.java
@@ -251,6 +251,24 @@ public class CalendarBookingTestUtil {
 	}
 
 	public static CalendarBooking addRecurringCalendarBooking(
+			Calendar invitingCalendar, Calendar invitedCalendar,
+			Recurrence recurrence, ServiceContext serviceContext)
+		throws PortalException {
+
+		User user = UserLocalServiceUtil.fetchUser(invitedCalendar.getUserId());
+
+		long startTime = System.currentTimeMillis();
+
+		return addCalendarBooking(
+			user, invitingCalendar,
+			new long[] {invitedCalendar.getCalendarId()},
+			RandomTestUtil.randomLocaleStringMap(),
+			RandomTestUtil.randomLocaleStringMap(), startTime,
+			startTime + (Time.HOUR * 10), recurrence, 0, null, 0, null,
+			serviceContext);
+	}
+
+	public static CalendarBooking addRecurringCalendarBooking(
 			User user, Calendar calendar, long startTime, long endTime,
 			Recurrence recurrence, ServiceContext serviceContext)
 		throws PortalException {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-74454
https://issues.liferay.com/browse/LPP-26631

Resent with semantic version change.

I've gone ahead and created a new template to handle individual CalendarBooking instance deletion and also added IM templates (even though it's not yet used). I also found a way to return to this pattern:
-User is notified with Deleted template if 1 occurrence is deleted
-User is notified with Updated template if multiple occurrences are deleted

I added to the integration test to test these changes. The email notifications now look like this:
![deletion notifications](https://user-images.githubusercontent.com/20051725/31091111-b5ad6980-a75e-11e7-968d-9d5f8fe1883d.png)