### PR TITLE
LPS-78301 Display localized complete weekday labels instead of standad English weekday abbreviations

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/calendar_booking_recurrence_container.jspf
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/calendar_booking_recurrence_container.jspf
@@ -138,10 +138,13 @@ if (recurrence != null) {
 					<aui:field-wrapper inlineField="<%= true %>" label="">
 
 						<%
+						String weekdayLabel = StringPool.BLANK;
+
 						for (Weekday weekday : weekdaysArray) {
+							weekdayLabel = "weekday" + StringPool.PERIOD + weekday.getValue();
 						%>
 
-							<aui:input checked="<%= weekdays.contains(weekday) %>" id="<%= weekday.getValue() %>" label="<%= weekday.getValue() %>" name="weekdays" type="checkbox" value="<%= weekday.getValue() %>" />
+							<aui:input checked="<%= weekdays.contains(weekday) %>" id="<%= weekday.getValue() %>" label="<%= weekdayLabel %>" name="weekdays" type="checkbox" value="<%= weekday.getValue() %>" />
 
 						<%
 						}


### PR DESCRIPTION
Hey @natocesarrego 

Following your request in https://github.com/natocesarrego/liferay-portal/pull/110#issuecomment-371612276 I'm submitting the solution of displaying the complete localized weekday labels instead of the abbreviations.

Best regards,
István