### PR TITLE
LPS-82502 Overlapping Calendar Events

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_models.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_models.js
@@ -218,6 +218,23 @@ AUI.add(
 						return instance.get('parentCalendarBookingId') === instance.get('calendarBookingId');
 					},
 
+					intersects: function(evt) {
+						var instance = this;
+						var endDate = instance.get('endDate');
+						var laterEndDate = DateMath.add(DateMath.clone(endDate), DateMath.MINUTES, 30);
+						var startDate = instance.get('startDate');
+						var evtStartDate = evt.get('startDate');
+
+						if (instance.sameStartDate(evt) ||
+							DateMath.between(evtStartDate, startDate, endDate)) {
+
+							return true;
+						}
+						else {
+							return DateMath.between(evtStartDate, startDate, laterEndDate);
+						}
+					},
+
 					isRecurring: function() {
 						var instance = this;
 


### PR DESCRIPTION
Hey @natocesarrego 

In case you are not the reviewer for Calendar, please ignore the pull request.
Unfortunately I could not found an up-to-date documentation on the members of the Calendar Engineering team like the one for the Forms team.

The issue is that no matter how small is time frame, the minimum size of the event's rectangle is of a half hour event. If event1 starts at say 11:53, and ends at 12:00, it will be covered entirely by event2 which start at say 12:00.

The event's rectangle height cannot be shortened because the name label would hang over the frame.

Normally, if an event is overlapped by a later event, the later event's width will be reduced half a column.
However, in the above case, event2's width will not be reduced, since it starts just after event1 ended.

The intersection detection logic is implemented in the `intersects()` function in **aui-scheduler-view-day.js**
The approach I used for solving the issue is to override the function in `scheduler_models.js` where `SchedulerEvent` is extended, by extending the timeframe of the event (endDate + 30 minutes) whom with other event's are compared for collision.

Thank you and best regards,
István