### PR TITLE
LPS-83662 Site Content Reviewer role can be deleted despite Workflow Definition associated with it

### DIFF
--- a/modules/apps/roles/roles-admin-web/build.gradle
+++ b/modules/apps/roles/roles-admin-web/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:portal-workflow:portal-workflow-kaleo-api")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:portlet-display-template:portlet-display-template-api")
 	compileOnly project(":apps:roles:roles-admin-api")

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/search/RoleChecker.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/search/RoleChecker.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.permission.RolePermissionUtil;
+import com.liferay.roles.admin.web.internal.util.RolesWorkflowUtil;
 
 import javax.portlet.PortletResponse;
 
@@ -42,7 +43,8 @@ public class RoleChecker extends EmptyOnClickRowChecker {
 			PermissionThreadLocal.getPermissionChecker();
 
 		try {
-			if (role.isSystem() ||
+			if (RolesWorkflowUtil.hasWorkflow(role.getRoleId()) ||
+				role.isSystem() ||
 				!RolePermissionUtil.contains(
 					permissionChecker, role.getRoleId(), ActionKeys.DELETE)) {
 

--- a/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/util/RolesWorkflowUtil.java
+++ b/modules/apps/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/util/RolesWorkflowUtil.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.roles.admin.web.internal.util;
+
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinition;
+import com.liferay.portal.workflow.kaleo.model.KaleoDefinitionVersion;
+import com.liferay.portal.workflow.kaleo.model.KaleoTaskAssignment;
+import com.liferay.portal.workflow.kaleo.service.KaleoDefinitionVersionLocalServiceUtil;
+import com.liferay.portal.workflow.kaleo.service.KaleoInstanceLocalServiceUtil;
+import com.liferay.portal.workflow.kaleo.service.KaleoTaskAssignmentLocalServiceUtil;
+
+import java.util.List;
+
+/**
+ * @author Istv�n Andr�s D�zsi
+ */
+public class RolesWorkflowUtil {
+
+	public static boolean hasWorkflow(long roleId) {
+		KaleoDefinitionVersion kaleoDefinitionVersion = null;
+		KaleoDefinition kaleoDefinition = null;
+
+		int count = 0;
+
+		try {
+			List<KaleoTaskAssignment> kaleoTaskAssignments =
+				KaleoTaskAssignmentLocalServiceUtil.getKaleoTaskAssignments(
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+			for (KaleoTaskAssignment kaleoTaskAssignment :
+					kaleoTaskAssignments) {
+
+				if (StringUtil.equals(
+						kaleoTaskAssignment.getAssigneeClassName(),
+						_ROLE_CLASS_NAME) &&
+					(kaleoTaskAssignment.getAssigneeClassPK() == roleId)) {
+
+					kaleoDefinitionVersion =
+						KaleoDefinitionVersionLocalServiceUtil.
+							getKaleoDefinitionVersion(
+								kaleoTaskAssignment.
+									getKaleoDefinitionVersionId());
+
+					kaleoDefinition =
+						kaleoDefinitionVersion.getKaleoDefinition();
+
+					if (kaleoDefinition.isActive()) {
+						return true;
+					}
+
+					count =
+						KaleoInstanceLocalServiceUtil.getKaleoInstancesCount(
+							kaleoDefinitionVersion.
+								getKaleoDefinitionVersionId(), false);
+
+					if (count > 0) {
+						return true;
+					}
+				}
+			}
+		}
+		catch (PortalException pe) {
+			_log.error(pe, pe);
+		}
+
+		return false;
+	}
+
+	private static final String _ROLE_CLASS_NAME = Role.class.getName();
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RolesWorkflowUtil.class);
+
+}

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -121,6 +121,7 @@ page import="com.liferay.roles.admin.web.internal.display.context.RoleDisplayCon
 page import="com.liferay.roles.admin.web.internal.display.context.SelectRoleManagementToolbarDisplayContext" %><%@
 page import="com.liferay.roles.admin.web.internal.display.context.ViewRolesManagementToolbarDisplayContext" %><%@
 page import="com.liferay.roles.admin.web.internal.util.PortletDisplayTemplateUtil" %><%@
+page import="com.liferay.roles.admin.web.internal.util.RolesWorkflowUtil" %><%@
 page import="com.liferay.taglib.search.ResultRow" %><%@
 page import="com.liferay.users.admin.kernel.util.UsersAdmin" %><%@
 page import="com.liferay.users.admin.kernel.util.UsersAdminUtil" %>

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/role_action.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/role_action.jsp
@@ -72,7 +72,7 @@ String name = role.getName();
 		/>
 	</c:if>
 
-	<c:if test="<%= !role.isSystem() && RolePermissionUtil.contains(permissionChecker, role.getRoleId(), ActionKeys.DELETE) %>">
+	<c:if test="<%= !RolesWorkflowUtil.hasWorkflow(role.getRoleId()) && !role.isSystem() && RolePermissionUtil.contains(permissionChecker, role.getRoleId(), ActionKeys.DELETE) %>">
 		<portlet:actionURL name="deleteRole" var="deleteRoleURL">
 			<portlet:param name="mvcPath" value="/edit_role.jsp" />
 			<portlet:param name="redirect" value="<%= currentURL %>" />


### PR DESCRIPTION
Hey @natocesarrego 

As you suggested, I added the validation steps 1. and 3., however, I could not figure out how to implement 2., as I could not found a way to associate the `KaleoDefinitionVersion` with the `KaleoDefinition` table in order to query the `active_` column.

I'll investigate this further tomorrow.

Best regards,
István