### PR TITLE
[TECHNICAL-SUPPORT] LPS-97097 Fix test

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormField.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/model/DDMFormField.java
@@ -137,6 +137,14 @@ public class DDMFormField implements Serializable {
 	}
 
 	public DDMFormFieldOptions getDDMFormFieldOptions() {
+		String dataSourceType = (String)_properties.get("dataSourceType");
+
+		if (Validator.isNotNull(dataSourceType) &&
+			!dataSourceType.equals("manual")) {
+
+			return new DDMFormFieldOptions();
+		}
+
 		return (DDMFormFieldOptions)_properties.get("options");
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/DDMFormFieldOptionsFactoryImpl.java
@@ -58,44 +58,35 @@ public class DDMFormFieldOptionsFactoryImpl
 		String dataSourceType = GetterUtil.getString(
 			ddmFormField.getProperty("dataSourceType"), "manual");
 
-		Object options = ddmFormFieldRenderingContext.getProperty("options");
-
-		if (Objects.equals(dataSourceType, "from-autofill")) {
-			List<?> list = (List<?>)options;
-
-			if (list.size() > 1) {
-				return createDDMFormFieldOptions(
-					ddmFormField, ddmFormFieldRenderingContext, options);
-			}
-
-			DDMFormFieldOptions ddmFormFieldOptions = new DDMFormFieldOptions();
-
-			ddmFormFieldOptions.setDefaultLocale(
-				ddmFormFieldRenderingContext.getLocale());
-
-			return ddmFormFieldOptions;
-		}
-		else if (Objects.equals(dataSourceType, "data-provider")) {
+		if (Objects.equals(dataSourceType, "data-provider")) {
 			return createDDMFormFieldOptionsFromDataProvider(
 				ddmFormField, ddmFormFieldRenderingContext);
 		}
 
 		return createDDMFormFieldOptions(
-			ddmFormField, ddmFormFieldRenderingContext, options);
+			ddmFormField, ddmFormFieldRenderingContext, dataSourceType);
 	}
 
 	protected DDMFormFieldOptions createDDMFormFieldOptions(
 		DDMFormField ddmFormField,
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext,
-		Object options) {
-
-		if (options == null) {
-			return ddmFormField.getDDMFormFieldOptions();
-		}
+		String dataSourceType) {
 
 		DDMFormFieldOptions ddmFormFieldOptions = new DDMFormFieldOptions();
 
-		for (Map<String, String> option : (List<Map<String, String>>)options) {
+		List<Map<String, String>> options =
+			(List<Map<String, String>>)ddmFormFieldRenderingContext.getProperty(
+				"options");
+
+		if (options == null) {
+			if (dataSourceType.equals("from-autofill")) {
+				return ddmFormFieldOptions;
+			}
+
+			return ddmFormField.getDDMFormFieldOptions();
+		}
+
+		for (Map<String, String> option : options) {
 			ddmFormFieldOptions.addOptionLabel(
 				option.get("value"), ddmFormFieldRenderingContext.getLocale(),
 				option.get("label"));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/evaluator/test/DDMFormFieldTypeSettingsEvaluatorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/form/evaluator/test/DDMFormFieldTypeSettingsEvaluatorTest.java
@@ -99,9 +99,7 @@ public class DDMFormFieldTypeSettingsEvaluatorTest {
 			(JSONArray)ddmDataProviderInstanceOutputFielPropertyChanges.get(
 				"value");
 
-		Assert.assertEquals(1, jsonArray.length());
-
-		Assert.assertEquals("Countries", jsonArray.getString(0));
+		Assert.assertEquals(0, jsonArray.length());
 	}
 
 	@Test

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/resource/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/resource/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-web/test/functional/com/liferay/portalweb/macros/AutoTagging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AutoTagging.macro
@@ -84,7 +84,7 @@ definition {
 				configurationName = "Asset Auto Tagging",
 				configurationScope = "Virtual Instance Scope");
 
-			Check(locator1 = "Checkbox#ENABLE_AUTO_TAGGING");
+			FormFields.enableCheckbox(fieldName = "enabled");
 
 			if (isSet(maximumNumberOfTags)) {
 				SystemSettings.editTextSetting(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/AutoTagging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AutoTagging.macro
@@ -70,6 +70,12 @@ definition {
 				configurationScope = "System Scope");
 
 			FormFields.enableCheckbox(fieldName = "enabled");
+
+			if (isSet(maximumNumberOfTags)) {
+				SystemSettings.editTextSetting(
+					settingName = "Maximum Number of Tags",
+					settingValue = "${maximumNumberOfTags}");
+			}
 		}
 
 		else if ("${enableAutoTaggingFor}" == "Instance Settings") {
@@ -77,7 +83,14 @@ definition {
 				configurationCategory = "Assets",
 				configurationName = "Asset Auto Tagging",
 				configurationScope = "Virtual Instance Scope");
+
 			Check(locator1 = "Checkbox#ENABLE_AUTO_TAGGING");
+
+			if (isSet(maximumNumberOfTags)) {
+				SystemSettings.editTextSetting(
+					settingName = "Maximum Number of Tags",
+					settingValue = "${maximumNumberOfTags}");
+			}
 		}
 
 		else if ("${enableAutoTaggingFor}" == "Settings") {
@@ -91,12 +104,29 @@ definition {
 			Check.checkToggleSwitch(locator1 = "Checkbox#ENABLE_AUTO_TAGGING");
 		}
 
-		if (IsElementPresent(locator1 = "Button#UPDATE")) {
-			PortletEntry.update();
-		}
+		if (isSet(validationError)) {
+			if (IsElementPresent(locator1 = "Button#UPDATE")) {
+				Button.clickUpdate();
+			}
 
-		else if (IsElementPresent(locator1 = "Button#SAVE")) {
-			PortletEntry.save();
+			else if (IsElementPresent(locator1 = "Button#SAVE")) {
+				Button.clickSave();
+			}
+
+			Alert.viewRequestFailedToComplete();
+
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#ERROR_1",
+				value1 = "${validationError}");
+		}
+		else {
+			if (IsElementPresent(locator1 = "Button#UPDATE")) {
+				PortletEntry.update();
+			}
+
+			else if (IsElementPresent(locator1 = "Button#SAVE")) {
+				PortletEntry.save();
+			}
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/UserBar.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/UserBar.macro
@@ -28,7 +28,7 @@ definition {
 
 	macro signOut {
 		if (IsElementNotPresent(locator1 = "UserBar#USER_SIGN_IN")) {
-			Click.pauseClickAt(locator1 = "UserBar#USER_AVATAR_IMAGE");
+			Click(locator1 = "UserBar#USER_AVATAR_IMAGE");
 
 			AssertVisible(locator1 = "UserBar#USER_AVATAR_DROPDOWN_PORTAL_OPEN");
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/userbar/UserBar.path
@@ -30,7 +30,7 @@
 </tr>
 <tr>
 	<td>USER_AVATAR_IMAGE</td>
-	<td>//span[@class='user-avatar-link']//div[contains(@class,'personal-menu-dropdown')]//*[name()='svg'][contains(@class,'lexicon-icon')]</td>
+	<td>//span[@class='user-avatar-link']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/autotagging/DMAutoTagging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/autotagging/DMAutoTagging.testcase
@@ -150,6 +150,21 @@ definition {
 		AutoTagging.assertNoAutoTag();
 	}
 
+	@description = "This test asserts that the max number of tags at the instance level cannot be greater than the max number of tags at the portal level."
+	@priority = "4"
+	test MaxNumberOfTagsCheckBetweenInstanceLevelAndPortalLevel {
+		property test.name.skip.portal.instance = "DMAutoTagging#MaxNumberOfTagsCheckBetweenInstanceLevelAndPortalLevel";
+
+		AutoTagging.enableAutoTagging(
+			enableAutoTaggingFor = "System Settings",
+			maximumNumberOfTags = "5");
+
+		AutoTagging.enableAutoTagging(
+			enableAutoTaggingFor = "Instance Settings",
+			maximumNumberOfTags = "10",
+			validationError = "Maximum number of tags cannot be greater than the maximum number of system tags.");
+	}
+
 	@description = "This test asserts that no auto-tags are generated for manually tagged images."
 	@priority = "4"
 	test NoAutoTagForManuallyTaggedImage {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/CPDocumentsandmedia.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/CPDocumentsandmedia.testcase
@@ -304,7 +304,7 @@ definition {
 		DMFolder.viewCP(dmFolderName = "DM Folder Name Name");
 	}
 
-	@description = "This test covers LPS-94820. This test ensures that only the last two checkin versions of a file are kept when the max version limit is set."
+	@description = "This test covers LPS-94820. This test ensures that only the last two checked in versions of a file are kept when the max version limit is set."
 	@priority = "4"
 	test LimitCheckInMaxFileVersion {
 		property test.name.skip.portal.instance = "CPDocumentsandmedia#LimitCheckInMaxFileVersion";
@@ -331,48 +331,48 @@ definition {
 
 		JSONDocument.addFile(
 			dmDocumentDescription = "DM Document Description",
-			dmDocumentTitle = "Checkin this document three times",
+			dmDocumentTitle = "Check in this document three times",
 			groupName = "Guest");
 
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
 
 		LexiconEntry.changeDisplayStyle(displayStyle = "list");
 
-		DMDocument.checkoutCP(dmDocumentTitle = "Checkin this document three times");
+		DMDocument.checkoutCP(dmDocumentTitle = "Check in this document three times");
 
 		Refresh();
 
 		DMDocument.checkinCP(
-			dmDocumentTitle = "Checkin this document three times",
+			dmDocumentTitle = "Check in this document three times",
 			revision = "Major");
 
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
 
 		LexiconEntry.changeDisplayStyle(displayStyle = "list");
 
-		DMDocument.checkoutCP(dmDocumentTitle = "Checkin this document three times");
+		DMDocument.checkoutCP(dmDocumentTitle = "Check in this document three times");
 
 		Refresh();
 
 		DMDocument.checkinCP(
-			dmDocumentTitle = "Checkin this document three times",
+			dmDocumentTitle = "Check in this document three times",
 			revision = "Major");
 
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
 
 		LexiconEntry.changeDisplayStyle(displayStyle = "list");
 
-		DMDocument.checkoutCP(dmDocumentTitle = "Checkin this document three times");
+		DMDocument.checkoutCP(dmDocumentTitle = "Check in this document three times");
 
 		Refresh();
 
 		DMDocument.checkinCP(
-			dmDocumentTitle = "Checkin this document three times",
+			dmDocumentTitle = "Check in this document three times",
 			revision = "Major");
 
 		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
 
-		DMNavigator.gotoDocumentCP(dmDocumentTitle = "Checkin this document three times");
+		DMNavigator.gotoDocumentCP(dmDocumentTitle = "Check in this document three times");
 
 		for (var versionNumber : list "3.0,4.0") {
 			AssertElementPresent(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/CPDocumentsandmedia.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/documentsadministration/CPDocumentsandmedia.testcase
@@ -304,6 +304,89 @@ definition {
 		DMFolder.viewCP(dmFolderName = "DM Folder Name Name");
 	}
 
+	@description = "This test covers LPS-94820. This test ensures that only the last two checkin versions of a file are kept when the max version limit is set."
+	@priority = "4"
+	test LimitCheckInMaxFileVersion {
+		property test.name.skip.portal.instance = "CPDocumentsandmedia#LimitCheckInMaxFileVersion";
+
+		SystemSettings.openSystemSettingsAdmin();
+
+		SystemSettings.gotoConfiguration(
+			configurationCategory = "Documents and Media",
+			configurationName = "Service",
+			configurationScope = "System Scope");
+
+		Type(
+			key_fieldLabel = "Maximum Number Of Versions",
+			locator1 = "TextInput#GENERIC_TEXT_INPUT",
+			value1 = "2");
+
+		ScrollWebElementIntoView(locator1 = "Button#SAVE");
+
+		AssertClick(
+			locator1 = "Button#SAVE",
+			value1 = "Save");
+
+		AssertElementPresent(locator1 = "Message#SUCCESS");
+
+		JSONDocument.addFile(
+			dmDocumentDescription = "DM Document Description",
+			dmDocumentTitle = "Checkin this document three times",
+			groupName = "Guest");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+		LexiconEntry.changeDisplayStyle(displayStyle = "list");
+
+		DMDocument.checkoutCP(dmDocumentTitle = "Checkin this document three times");
+
+		Refresh();
+
+		DMDocument.checkinCP(
+			dmDocumentTitle = "Checkin this document three times",
+			revision = "Major");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+		LexiconEntry.changeDisplayStyle(displayStyle = "list");
+
+		DMDocument.checkoutCP(dmDocumentTitle = "Checkin this document three times");
+
+		Refresh();
+
+		DMDocument.checkinCP(
+			dmDocumentTitle = "Checkin this document three times",
+			revision = "Major");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+		LexiconEntry.changeDisplayStyle(displayStyle = "list");
+
+		DMDocument.checkoutCP(dmDocumentTitle = "Checkin this document three times");
+
+		Refresh();
+
+		DMDocument.checkinCP(
+			dmDocumentTitle = "Checkin this document three times",
+			revision = "Major");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+		DMNavigator.gotoDocumentCP(dmDocumentTitle = "Checkin this document three times");
+
+		for (var versionNumber : list "3.0,4.0") {
+			AssertElementPresent(
+				key_dmDocumentVersionNumber = "${versionNumber}",
+				locator1 = "DocumentsAndMedia#DOCUMENT_VERSION_ANY");
+		}
+
+		for (var versionNumber : list "1.0,2.0") {
+			AssertElementNotPresent(
+				key_dmDocumentVersionNumber = "${versionNumber}",
+				locator1 = "DocumentsAndMedia#DOCUMENT_VERSION_ANY");
+		}
+	}
+
 	@description = "This test ensures that only the last two versions of a file are kept when the max version limit is set."
 	@priority = "5"
 	test LimitMaxFileVersion {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/workflow/WorkflowDocumentsAndMedia.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/workflow/WorkflowDocumentsAndMedia.testcase
@@ -270,6 +270,21 @@ definition {
 			dmFolderName = "DM Folder Name",
 			workflowRestriction = "Parent Folder");
 
+		DMNavigator.gotoDocumentType();
+
+		DMDocumentType.add(
+			dmDocumentTypeDescription = "DM Document Type Description",
+			dmDocumentTypeFieldNames = "Text Box",
+			dmDocumentTypeName = "DM Document Type Name");
+
+		DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "guest");
+
+		DMFolder.configureWorkflowCP(
+			dmDocumentTypeName = "DM Document Type Name",
+			dmFolderName = "DM Folder Name",
+			workflowDefinition = "Single Approver",
+			workflowRestriction = "Specific Restrictions");
+
 		DMFolder.configureWorkflowCP(
 			dmFolderName = "DM Folder Name",
 			workflowDefinition = "No Workflow",


### PR DESCRIPTION
Related tickets:
https://issues.liferay.com/browse/LPS-97097

Note: turns out, @natocesarrego, we only need that logic for the `CallFunction` class in **7.1**. The master branch already changed the product behavior to ["not not auto select an option for the user"](https://github.com/liferay/liferay-portal/commit/4b931e9f971b84e73398050a8204e7eb0550a1a8). So this pull request doesn't need https://github.com/natocesarrego/liferay-portal-ee/pull/54/commits/48d0a7809cbab92e717b6b7987f025a13d551a5b, https://github.com/natocesarrego/liferay-portal-ee/pull/54/commits/cf5cb8c2f3458b9cb09f22c688aa4e15d13d707f or https://github.com/natocesarrego/liferay-portal-ee/pull/54/commits/4588af4bbc2147360232311baa4cc9bdece917a3#diff-2e4acca9a258e7f1bc4bb209ef4744a3

I'll make sure that 7.1 receives that change as we've discussed once it's time to backport.
Thanks.