### PR TITLE
[TECHNICAL SUPPORT] LPS-97871 Filtering and ordering options in workflow tasks become disabled if selecting a filter with zero results

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/toolbar.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/instance/toolbar.jsp
@@ -18,7 +18,7 @@
 
 <clay:management-toolbar
 	clearResultsURL="<%= workflowInstanceViewDisplayContext.getClearResultsURL() %>"
-	disabled="<%= workflowInstanceViewDisplayContext.isDisabledManagementBar() %>"
+	disabled="false"
 	filterDropdownItems="<%= workflowInstanceViewDisplayContext.getFilterOptions(request) %>"
 	itemsTotal="<%= workflowInstanceViewDisplayContext.getTotalItems() %>"
 	namespace="<%= renderResponse.getNamespace() %>"


### PR DESCRIPTION
Hey,

[LPS-97871](https://issues.liferay.com/browse/LPS-97871),

I visited Lexicon 2.0, and I saw an extended documentation about the Empty state, but nothing about disabling the toolbar, while there is no result. I think the logic inside isDisabledManagementBar() can be tweaked as well, however I simply decided to permanently make the disabled attribute of the toolbar "false".
Please review my change.

Thanks,