### PR TITLE
[TECHNICAL SUPPORT] LPS-97871 Filtering and ordering options in workflow tasks become disabled if selecting a filter with zero results

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/toolbar.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/toolbar.jsp
@@ -50,7 +50,6 @@ portletURL.setParameter("tabs1", tabs1);
 
 <clay:management-toolbar
 	clearResultsURL="<%= workflowTaskDisplayContext.getClearResultsURL() %>"
-	disabled="<%= workflowTaskDisplayContext.isManagementBarDisabled() %>"
 	filterDropdownItems="<%= workflowTaskDisplayContext.getFilterOptions() %>"
 	itemsTotal="<%= workflowTaskDisplayContext.getTotalItems() %>"
 	namespace="<%= renderResponse.getNamespace() %>"


### PR DESCRIPTION
Hey @natocesarrego,

[LPS-97871](https://issues.liferay.com/browse/LPS-97871) / [PTR-1063](https://issues.liferay.com/browse/PTR-1063) 

Please review it.

Thanks, 