### PR TITLE
[TECHNICAL SUPPORT]LPS-100416 Non-Repeatable text fields show incorrect translation on label at first load

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -444,9 +444,10 @@ AUI.add(
 
 					if (instance.get('repeatable')) {
 						instance.renderRepeatableUI();
-						instance.syncLabel(instance.get('displayLocale'));
 						instance.syncRepeatablelUI();
 					}
+
+					instance.syncLabel(instance.get('displayLocale'));
 
 					instance.syncValueUI();
 


### PR DESCRIPTION
Hey @natocesarrego,

We found a regression with [LPS-98659](https://issues.liferay.com/browse/LPS-98659), when made a hotfix. I simply forget about non-repeatable fields when the instance default locale and the structure's default locale is not the same.

I quickly made a fix for it, please review it. -> [LPS-100416](https://issues.liferay.com/browse/LPS-100416)

Thanks