### PR TITLE
[TS] LPS-101544 

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
@@ -62,6 +62,7 @@ import java.net.URL;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -101,10 +102,14 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 			boolean showEmptyFieldLabel =
 				ddmFormFieldRenderingContext.isShowEmptyFieldLabel();
 
+			Locale locale = ddmFormFieldRenderingContext.getLocale();
+
+			locale = getDefaultLocale(locale, ddmFormField);
+
 			return getFieldHTML(
 				httpServletRequest, httpServletResponse, ddmFormField, fields,
 				null, portletNamespace, namespace, mode, readOnly,
-				showEmptyFieldLabel, ddmFormFieldRenderingContext.getLocale());
+				showEmptyFieldLabel, locale);
 		}
 		catch (Exception e) {
 			throw new PortalException(e);
@@ -231,6 +236,29 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 		return sb.toString();
 	}
 
+	protected Locale getDefaultLocale(
+		Locale locale, DDMFormField ddmFormField) {
+
+		DDMForm ddmForm = ddmFormField.getDDMForm();
+
+		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
+
+		if (!availableLocales.contains(locale)) {
+			if (availableLocales.size() == 1) {
+				Iterator iter = availableLocales.iterator();
+
+				locale = (Locale)iter.next();
+
+				ddmForm.setDefaultLocale(locale);
+			}
+			else {
+				locale = ddmForm.getDefaultLocale();
+			}
+		}
+
+		return locale;
+	}
+
 	protected Map<String, Object> getFieldContext(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse, String portletNamespace,
@@ -248,19 +276,9 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 			return fieldContext;
 		}
 
-		DDMForm ddmForm = ddmFormField.getDDMForm();
-
-		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
-
-		Locale structureLocale = locale;
-
-		if (!availableLocales.contains(locale)) {
-			structureLocale = ddmForm.getDefaultLocale();
-		}
-
 		fieldContext = new HashMap<>();
 
-		addLayoutProperties(ddmFormField, fieldContext, structureLocale);
+		addLayoutProperties(ddmFormField, fieldContext, locale);
 
 		addStructureProperties(ddmFormField, fieldContext);
 


### PR DESCRIPTION
Hello @natocesarrego ,

Notes from @matthewchan1:

> https://issues.liferay.com/browse/LPS-101544
> 
> Issue:
> Changing a site's default locale in site configurations, then limiting available locales to just that language is defaulting to blank text for custom web content fields.
> 
> The main problem is that neither the current nor default translations are present in availableLocales. In this case, since there is just one availableLocales value, it will be more user-friendly to display the existing localization rather than empty fields.
> 
> Fix:
> Locale is passed from in a chain of function calls in DDMFormFieldFreeMarkerRenderer.java, so changing the locale in render() at the highest level will fix problems with both field options and titles appearing blank. I just fetched the locale in availableLocales and set it as the default language. The result is text reappears as per its definition in the Edit Structure page.

We are aware that Forms issue should have been directed to BR team, but the issue was not identified as a Forms issue until a bit too much work was committed. We will be more careful next time and redirect properly and sooner.

Please let us know if you have any questions about the fix. Thanks.

Sincerely,
Brian Kim