### PR TITLE
LPS-102643 Problem saving decimal metadata with italian locale

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/FieldConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/FieldConstants.java
@@ -135,6 +135,10 @@ public class FieldConstants {
 			return StringPool.BLANK;
 		}
 
+		if (isNumericType(type)) {
+			value = value.replace(',','.');
+		}
+
 		if (type.equals(BOOLEAN)) {
 			return GetterUtil.getBoolean(value);
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/FieldConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/storage/FieldConstants.java
@@ -136,7 +136,7 @@ public class FieldConstants {
 		}
 
 		if (isNumericType(type)) {
-			value = value.replace(',','.');
+			value = value.replace(',', '.');
 		}
 
 		if (type.equals(BOOLEAN)) {


### PR DESCRIPTION
Hi @natocesarrego 
Could you please review this pull request?

After examining the code causing the error, I found that only a lot of changes could pass the Locale value for the GetterUtil.get() (514.line). Realy lot. Currently, we set Locale value to null when we call the get method and throw an error in 525. line because Java can't parse a string with a comma separator. While I debugged, I changed the Locale value to an existing object, to go across this exception and see what's happening. I realized that we cant change the parse method in 534 line. That's why I choose this solution.
Thank you and best regards,
Marci

https://issues.liferay.com/browse/LPS-102643