### PR TITLE
LPS-105059 'Manage templates' dropdown is not updated after adding a new template

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -100,6 +100,14 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 					basePortletURL: '<%= basePortletURL %>',
 					classNameId: '<%= classNameId %>',
 					dialog: {
+						after: {
+							destroy(event) {
+								if (event.target.get('destroyOnHide')) {
+									window.location.reload();
+								}
+							}
+						},
+						destroyOnHide: true,
 						width: 1024
 					},
 					groupId: <%= ddmTemplateGroupId %>,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -95,38 +95,27 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 
 	if (selectDDMTemplateLink) {
 		selectDDMTemplateLink.addEventListener('click', function(event) {
-			Liferay.Util.openDDMPortlet(
-				{
-					basePortletURL: '<%= basePortletURL %>',
-					classNameId: '<%= classNameId %>',
-					dialog: {
-						after: {
-							destroy(event) {
-								if (event.target.get('destroyOnHide')) {
-									window.location.reload();
-								}
-							}
-						},
-						destroyOnHide: true,
-						width: 1024
+			Liferay.Util.openDDMPortlet({
+				basePortletURL: '<%= basePortletURL %>',
+				classNameId: '<%= classNameId %>',
+				dialog: {
+					after: {
+						destroy() {
+							submitForm(
+								document.<portlet:namespace />fm,
+								'<%= HtmlUtil.escapeJS(refreshURL) %>'
+							);
+						}
 					},
-					groupId: <%= ddmTemplateGroupId %>,
-					mvcPath: '/view_template.jsp',
-					navigationStartsOn: '<%= DDMNavigationHelper.VIEW_TEMPLATES %>',
-					refererPortletName:
-						'<%= PortletKeys.PORTLET_DISPLAY_TEMPLATE %>',
-					title:
-						'<%= UnicodeLanguageUtil.get(request, "widget-templates") %>'
+					destroyOnHide: true,
+					width: 1024
 				},
-				function(event) {
-					if (!event.newVal) {
-						submitForm(
-							document.<portlet:namespace />fm,
-							'<%= HtmlUtil.escapeJS(refreshURL) %>'
-						);
-					}
-				}
-			);
+				groupId: <%= ddmTemplateGroupId %>,
+				mvcPath: '/view_template.jsp',
+				navigationStartsOn: '<%= DDMNavigationHelper.VIEW_TEMPLATES %>',
+				refererPortletName: '<%= PortletKeys.PORTLET_DISPLAY_TEMPLATE %>',
+				title: '<%= UnicodeLanguageUtil.get(request, "widget-templates") %>'
+			});
 		});
 	}
 


### PR DESCRIPTION
Hi @natocesarrego ,

Can you review this pull request, please?

It's a bit hacky so let me explain it a little bit.

- The original callback should update our dropdown but it is never called. 
- It should be called [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js#L1454) when eventName is triggered. Since we are not explicitely passing any eventName, then we take the [default](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js#L1369-L1371) one, _selectStructure_. But that event _selectStructure_ is never triggered in our workflow.
- My first idea was using [selectEntityHandler](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js#L1036) API since we can pass a container and an event to be triggered, just following [the pattern](https://github.com/liferay/liferay-portal/blob/master/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entry.jsp#L70-L75) we use in many places in portal. So I could trigger _selectStructure_ event for our form.
- But that does not work here because we don't have any ['.selector-button'](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js#L1041) in our view-template.jsp
- So, we've decided to execute the code within the callback when the dialog is destroyed.

Let me know whether you have any doubt.

Thanks.

Regards.

/cc @robertoDiaz, @crodriguezy