### PR TITLE
Lps 105059 'Manage templates' dropdown is not updated after adding a new template

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -100,10 +100,9 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 					basePortletURL: '<%= basePortletURL %>',
 					classNameId: '<%= classNameId %>',
 					dialog: {
-						destroyOnHide: true,
 						width: 1024
 					},
-					eventName: 'saveTemplate',
+					eventName: '<portlet:namespace />saveTemplate',
 					groupId: <%= ddmTemplateGroupId %>,
 					mvcPath: '/view_template.jsp',
 					navigationStartsOn: '<%= DDMNavigationHelper.VIEW_TEMPLATES %>',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/template_selector/page.jsp
@@ -100,8 +100,10 @@ Group ddmTemplateGroup = GroupLocalServiceUtil.getGroup(ddmTemplateGroupId);
 					basePortletURL: '<%= basePortletURL %>',
 					classNameId: '<%= classNameId %>',
 					dialog: {
+						destroyOnHide: true,
 						width: 1024
 					},
+					eventName: 'saveTemplate',
 					groupId: <%= ddmTemplateGroupId %>,
 					mvcPath: '/view_template.jsp',
 					navigationStartsOn: '<%= DDMNavigationHelper.VIEW_TEMPLATES %>',

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -1454,6 +1454,8 @@
 			var eventHandles = [Liferay.once(config.eventName, callback)];
 
 			var detachSelectionOnHideFn = function(event) {
+				Liferay.fire(config.eventName);
+
 				if (!event.newVal) {
 					new A.EventHandle(eventHandles).detach();
 				}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -1451,7 +1451,13 @@
 				config.dialog = dialogConfig;
 			}
 
-			var eventHandles = [Liferay.once(config.eventName, callback)];
+			var eventHandles = []
+			
+			if (callback) {
+				eventHandles.push(
+					Liferay.once(config.eventName, callback)
+				);
+			}
 
 			var detachSelectionOnHideFn = function(event) {
 				Liferay.fire(config.eventName);


### PR DESCRIPTION
Hi @natocesarrego ,

Based on your proposal [here](https://github.com/natocesarrego/liferay-portal/pull/198#issuecomment-561335237), I've created this new and cleaner pull request.

Although since now we are not getting rid of the callback and I could have skipped the second commit, I think it's a good practice to include that check, just in case in other uses of Liferay.Util.openDDMPortlet someone decides not to add any callback.

Thanks.

Regards.

/cc @robertoDiaz , @crodriguezy 