### PR TITLE
[TECHNICAL-SUPPORT] LPS-105572 DDM form in Asset Publisher filter configuration

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/select_structure_field.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/select_structure_field.jsp
@@ -36,6 +36,7 @@ portletURL.setParameter("mvcPath", "/select_structure_field.jsp");
 portletURL.setParameter("portletResource", portletResource);
 portletURL.setParameter("className", className);
 portletURL.setParameter("classTypeId", String.valueOf(classTypeId));
+portletURL.setParameter("eventName", eventName);
 %>
 
 <div class="alert alert-danger hide" id="<portlet:namespace />message">

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1037,6 +1037,10 @@ AUI.add(
 						}
 
 						if (Lang.isUndefined(value)) {
+							value = instance.getValue();
+						}
+
+						if (Lang.isUndefined(value)) {
 							value = instance.getDefaultLocalization(
 								instance.get('displayLocale')
 							);


### PR DESCRIPTION
Hi @natocesarrego ,

This fix consist of 2 parts:
* https://github.com/natocesarrego/liferay-portal/commit/d3173f4c8f93ca6075e576237c0ee7afb9ffd0aa : an earlier fix, [LPS-98527](https://issues.liferay.com/browse/LPS-98527) replaced a part of `ddm_form.js`, where the original value of the field is written back when executing `syncValueUI` function: https://github.com/liferay/liferay-portal/commit/b5084d15da49fa3986fd2221f7e187506eed1fc4#diff-31faafccfa051120833493e5350865abL869
I added this part of code back, otherwise an empty string is returned to the AP configuration form.
* https://github.com/natocesarrego/liferay-portal/commit/6e8bc84c7b04cbaf62a0285e1e8950b4aeb77d1d this is more AP configuration related: `eventName` should be in the URL, or a new one is generated during pagination.

cc: @rolandpakai

Please review my changes.

Thanks,
Vendel
