### PR TITLE
LPS-106637 Use correct name of field to create the specific search filter

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceRecordIndexer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/DDMFormInstanceRecordIndexer.java
@@ -118,11 +118,11 @@ public class DDMFormInstanceRecordIndexer
 		}
 
 		long ddmFormInstanceId = GetterUtil.getLong(
-			searchContext.getAttribute("ddmFormInstanceId"));
+			searchContext.getAttribute("formInstanceId"));
 
 		if (ddmFormInstanceId > 0) {
 			contextBooleanFilter.addRequiredTerm(
-				"ddmFormInstanceId", ddmFormInstanceId);
+				"formInstanceId", ddmFormInstanceId);
 		}
 
 		addSearchClassTypeIds(contextBooleanFilter, searchContext);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMFormInstanceRecordModelPreFilterContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/search/spi/model/query/contributor/DDMFormInstanceRecordModelPreFilterContributor.java
@@ -61,11 +61,10 @@ public class DDMFormInstanceRecordModelPreFilterContributor
 		}
 
 		long ddmFormInstanceId = GetterUtil.getLong(
-			searchContext.getAttribute("ddmFormInstanceId"));
+			searchContext.getAttribute("formInstanceId"));
 
 		if (ddmFormInstanceId > 0) {
-			booleanFilter.addRequiredTerm(
-				"ddmFormInstanceId", ddmFormInstanceId);
+			booleanFilter.addRequiredTerm("formInstanceId", ddmFormInstanceId);
 		}
 
 		addSearchClassTypeIds(booleanFilter, searchContext);


### PR DESCRIPTION
Relevant ticket:
https://issues.liferay.com/browse/LPS-106637

**Notes:** When backporting, 7.1.x will have the same fix as _DDMFormInstanceRecordModelPreFilterContributor_, but inside the now deprecated _DDMFormInstanceRecordIndexer_. That's why I chose to include the fix for _DDMFormInstanceRecordIndexer_ on master too... to maintain consistency between the master and legacy code.