### PR TITLE
LPS-109868 Separator field with nested fields has no translations

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1116,7 +1116,9 @@ AUI.add(
 
 					var dataType = instance.get('dataType');
 
-					if (dataType) {
+					var fields = instance.get('fields');
+
+					if (dataType || fields.length) {
 						instance.updateLocalizationMap(
 							instance.get('displayLocale')
 						);
@@ -1131,8 +1133,6 @@ AUI.add(
 							);
 						}
 					}
-
-					var fields = instance.get('fields');
 
 					if (fields.length) {
 						fieldJSON.nestedFieldValues = AArray.invoke(


### PR DESCRIPTION
Hi @natocesarrego 

Could you please review this pull request?

Separator fields do not have a `dataType` field, but they are necessary for their localizations to be updated.
This does not pose a problem if they contain no data, but if they have nested fields, the new translations won't be added.

Thank you and best regards,
István