### PR TITLE
[TECHNICAL-SUPPORT] LPS-110343 Form references not correctly exported when forms are not staged

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/test/DDMFormDisplayExportImportTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/test/DDMFormDisplayExportImportTest.java
@@ -112,6 +112,9 @@ public class DDMFormDisplayExportImportTest
 		Map<String, String[]> preferenceMap = HashMapBuilder.put(
 			"formInstanceId",
 			new String[] {String.valueOf(ddmFormInstance.getFormInstanceId())}
+		).put(
+			"groupId",
+			new String[] {String.valueOf(ddmFormInstance.getGroupId())}
 		).build();
 
 		PortletPreferences importedPortletPreferences =


### PR DESCRIPTION
Hi @natocesarrego ,

I've changed the export of the DDM Form Portlet preferences: it should not export the Form instance as missing reference when Forms are not staged.

Please review my changes.

Thanks,
Vendel