### PR TITLE
LPS-110839 setting empty value when field gets hidden

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-evaluator-impl/src/main/java/com/liferay/dynamic/data/mapping/form/evaluator/internal/helper/DDMFormEvaluatorHelper.java
@@ -41,6 +41,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormRule;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -135,7 +136,16 @@ public class DDMFormEvaluatorHelper {
 		stream.filter(
 			DDMFormRule::isEnabled
 		).forEach(
-			this::evaluateDDMFormRule
+			rule -> {
+				evaluateDDMFormRule(rule);
+
+				_ddmFormFieldsPropertyChanges.forEach(
+					(key, value) -> {
+						if (!isFieldVisible(key)) {
+							value.put("value", StringPool.BLANK);
+						}
+					});
+			}
 		);
 
 		verifyFieldsMarkedAsRequired();


### PR DESCRIPTION
Hi @natocesarrego ,
with this approach, the value is set to empty after the rule evaluation has changed the "visible" property. This way the form context will be also updated and the field value will be reset.
Thanks!