### PR TITLE
LPS-114001 Placeholder value is overwritten by current value and it can accidentally create a new translation every time we visit a locale

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1083,10 +1083,6 @@ AUI.add(
 						}
 
 						if (Lang.isUndefined(value)) {
-							value = instance.getValue();
-						}
-
-						if (Lang.isUndefined(value)) {
 							value = instance.getDefaultLocalization(
 								instance.get('displayLocale')
 							);


### PR DESCRIPTION
Hey,

In this commit I'm partially reverting [LPS-105572](https://issues.liferay.com/browse/LPS-105572). After the revert LPS-105572 was not reproducible.

I reverted this commit as we used the the current value as a placeholder text when the user visited a new locale. This can lead to unwanted creation of new translations, when the current value is different than the default locale's value at updateLocalizationMap() in ddm_form.js.
You can find reproduction steps at [LPS-114001](https://issues.liferay.com/browse/LPS-114001)

Please review it,

Thanks