### PR TITLE
Lps 86235 data engine data form

### DIFF
--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/DDLPortlet.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/portlet/DDLPortlet.java
@@ -73,6 +73,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 		"com.liferay.portlet.header-portlet-javascript=/js/main.js",
 		"com.liferay.portlet.icon=/icons/dynamic_data_lists.png",
 		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.render-weight=50",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/java/com/liferay/dynamic/data/mapping/data/provider/web/internal/portlet/DDMDataProviderPortlet.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-data-provider-web/src/main/java/com/liferay/dynamic/data/mapping/data/provider/web/internal/portlet/DDMDataProviderPortlet.java
@@ -48,6 +48,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.instanceable=false",
 		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.render-weight=50",


### PR DESCRIPTION
Hi @natocesarrego 

There are several portlets that are non deployable but has property set to PreferencesUniquePerLayout=true(the default value), DDL and DDMDataProvider are two of them.

This commit explicitly set it to false.