### PR TITLE
LPS-118184 Format date in exported entries

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/exporter/DDMFormInstanceRecordExporterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/io/exporter/DDMFormInstanceRecordExporterImpl.java
@@ -39,12 +39,15 @@ import com.liferay.dynamic.data.mapping.util.comparator.FormInstanceVersionVersi
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+
+import java.text.Format;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -185,8 +188,6 @@ public class DDMFormInstanceRecordExporterImpl
 			List<DDMFormInstanceRecord> ddmFormInstanceRecords, Locale locale)
 		throws Exception {
 
-		DateTimeFormatter dateTimeFormatter = getDateTimeFormatter(locale);
-
 		List<Map<String, String>> ddmFormFieldValues = new ArrayList<>();
 
 		for (DDMFormInstanceRecord ddmFormInstanceRecord :
@@ -222,11 +223,13 @@ public class DDMFormInstanceRecordExporterImpl
 				getStatusMessage(
 					ddmFormInstanceRecordVersion.getStatus(), locale));
 
+			Format dateFormatDateTime = FastDateFormatFactoryUtil.getDateTime(
+				locale);
+
 			ddmFormFieldsValue.put(
 				_MODIFIED_DATE,
-				formatDate(
-					ddmFormInstanceRecordVersion.getStatusDate(),
-					dateTimeFormatter));
+				dateFormatDateTime.format(
+					ddmFormInstanceRecordVersion.getStatusDate()));
 
 			ddmFormFieldsValue.put(
 				_AUTHOR, ddmFormInstanceRecordVersion.getUserName());


### PR DESCRIPTION
Hi @natocesarrego ,

Can you review this pull request, please?

In [LPS-118184](https://issues.liferay.com/browse/LPS-118184) you can see the steps to reproduce it. 

Regarding the solution, I had in mind that if after carried out step 4:

> Using basque as user locale, go to Site Admin => Content => Forms => Select the option 'View entries' in our form.

I hover over modified date field I can see the tooltip showing the date with the expected format, what was different from the format I could see after exporting the data in a file.

So, I figured out that tooltip in printed from [here](https://github.com/liferay/liferay-portal/blob/master/util-taglib/src/com/liferay/taglib/search/DateSearchEntry.java#L48-L57) and I brought the same pattern.

Thanks.

Regards.