### PR TITLE
LPS-125499 Check if the file size exceeds the upload request size limit before sending the file

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/DocumentLibrary/DocumentLibrary.es.js
@@ -346,9 +346,39 @@ const Main = ({
 		document.getElementById('ddm-form-submit').disabled = disable;
 	};
 
+	const isExceededUploadRequestSizeLimit = (fileSize) => {
+		const uploadRequestSizeLimit =
+			Liferay.PropsValues.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE;
+
+		if (fileSize <= uploadRequestSizeLimit) {
+			return false;
+		}
+
+		const errorMessage = Liferay.Util.sub(
+			Liferay.Language.get(
+				'please-enter-a-file-with-a-valid-file-size-no-larger-than-x'
+			),
+			[Liferay.Util.formatStorage(uploadRequestSizeLimit)]
+		);
+
+		configureErrorMessage(errorMessage);
+
+		setCurrentValue(null);
+
+		onChange({}, '{}');
+
+		return true;
+	};
+
 	const handleUploadSelectButtonClicked = (event) => {
+		const file = event.target.files[0];
+
+		if (isExceededUploadRequestSizeLimit(file.size)) {
+			return;
+		}
+
 		const data = {
-			[`${portletNamespace}file`]: event.target.files[0],
+			[`${portletNamespace}file`]: file,
 		};
 
 		axios
@@ -385,6 +415,10 @@ const Main = ({
 					onChange(event, JSON.stringify(file));
 				}
 
+				setProgress(0);
+			})
+			.catch(() => {
+				disableSubmitButton(false);
 				setProgress(0);
 			});
 	};


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-125499

As we discussed, I did an investigation to find out how **Documents and Media** handles the case when the file size is larger than the size defined by the **Overall Maximum Upload Request Size** property and I ended up discovering that the [ItemSelectorRepositoryEntryBrowser.es.js](https://github.com/liferay/liferay-portal/blob/9abb5412f865531a30c879edc61e94795e419bce/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/js/ItemSelectorRepositoryEntryBrowser.es.js#L473) is responsible for doing a validation before sending the file to the backend.
Because of that, I implemented the validation in the DocumentLibrary, as you can see in this PR. 