### PR TITLE
LPS-90833 [New Form Builder] The plus icon (repeatable) is overlapping a long label

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -246,7 +246,8 @@ function FieldBase({
 									aria-describedby={fieldDetailsId}
 									className={classNames({
 										'ddm-empty': !showLabel && !required,
-										'ddm-label': showLabel || required,
+										'ddm-label-repeatable': (showLabel || required) && repeatable,
+										'ddm-label': (showLabel || required) && !repeatable,
 									})}
 									tabIndex="0"
 								>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
@@ -81,7 +81,7 @@ body .ddm-user-view-content {
 
 
 .ddm-field label {
-	padding-right: 40px;
+	padding-right: 45px;
 }
 
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
@@ -79,6 +79,12 @@ body .ddm-user-view-content {
 	font-weight: 500;
 }
 
+
+.ddm-field label {
+	padding-right: 40px;
+}
+
+
 .lfr-ddm-form-field-container label,
 .lfr-ddm-form-field-container legend,
 .lfr-ddm-form-field-container p {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
@@ -79,12 +79,6 @@ body .ddm-user-view-content {
 	font-weight: 500;
 }
 
-
-.ddm-field label {
-	padding-right: 45px;
-}
-
-
 .lfr-ddm-form-field-container label,
 .lfr-ddm-form-field-container legend,
 .lfr-ddm-form-field-container p {
@@ -639,6 +633,18 @@ p.ddm-label {
 	margin-bottom: 0.25rem;
 	max-width: 100%;
 	word-wrap: break-word;
+}
+
+p.ddm-label-repeatable {
+	color: #272833;
+	cursor: default;
+	display: inline-block;
+	font-size: 0.875rem;
+	font-weight: 600;
+	margin-bottom: 0.25rem;
+	max-width: 100%;
+	word-wrap: break-word;
+	padding-right: 50px;
 }
 
 legend .reference-mark,


### PR DESCRIPTION
Fixes repeatable plus button overlap on long labels.

The fix was achieved by creating a new `ddm-label-repeatable` css class, which changes the label behavior so that it isn't overlapped by the plus and minus icons when the repeatable flag is true on the form component