### PR TITLE
LPS-129268 Visual Glitch on Submit button when highlighted by the tab key

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
@@ -182,6 +182,8 @@ body .ddm-user-view-content {
 	}
 
 	.lfr-ddm-form-pagination-controls {
+		padding-left: 12px;
+		padding-right: 12px;
 		padding-top: 20px;
 
 		button {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/DynamicDataMappingUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v1_0_0/DynamicDataMappingUpgradeProcess.java
@@ -2192,20 +2192,14 @@ public class DynamicDataMappingUpgradeProcess extends UpgradeProcess {
 
 			int parentOffset = ddmFieldsCounter.get(fieldName);
 
-			Map<String, DDMFormField> nestedDDMFormFieldsMap =
-				ddmFormField.getNestedDDMFormFieldsMap();
-
 			String[] ddmFieldsDisplayValues = getDDMFieldsDisplayValues(
 				rootElement, true);
 
-			for (Map.Entry<String, DDMFormField> nestedDDMFormFieldEntry :
-					nestedDDMFormFieldsMap.entrySet()) {
+			List<DDMFormField> nestedDDMFormFields =
+				ddmFormField.getNestedDDMFormFields();
 
-				String nestedDDMFormFieldName =
-					nestedDDMFormFieldEntry.getKey();
-
-				DDMFormField nestedDDMFormField =
-					nestedDDMFormFieldEntry.getValue();
+			for (DDMFormField nestedDDMFormField : nestedDDMFormFields) {
+				String nestedDDMFormFieldName = nestedDDMFormField.getName();
 
 				int repetitions = countDDMFieldRepetitions(
 					ddmFieldsDisplayValues, nestedDDMFormFieldName, fieldName,

--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/layout/dynamic/data/mapping/form/field/type/internal/LayoutDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/layout/dynamic/data/mapping/form/field/type/internal/LayoutDDMFormFieldTemplateContextContributor.java
@@ -137,34 +137,41 @@ public class LayoutDDMFormFieldTemplateContextContributor
 		try {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(value);
 
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			long groupId = GetterUtil.getLong(
+				defaultGroupId, serviceContext.getScopeGroupId());
+
 			if (jsonObject.has("groupId")) {
-				return value;
+				groupId = jsonObject.getLong("groupId");
 			}
 
 			boolean privateLayout = jsonObject.getBoolean("privateLayout");
 			long layoutId = jsonObject.getLong("layoutId");
 
-			ServiceContext serviceContext =
-				ServiceContextThreadLocal.getServiceContext();
-
 			Layout layout = _layoutLocalService.fetchLayout(
-				GetterUtil.getLong(
-					defaultGroupId, serviceContext.getScopeGroupId()),
-				privateLayout, layoutId);
+				groupId, privateLayout, layoutId);
 
 			if (layout == null) {
 				return StringPool.BLANK;
 			}
 
-			jsonObject.put(
-				"groupId", layout.getGroupId()
-			).put(
-				"id", layout.getUuid()
-			).put(
-				"name", layout.getName(defaultLocale)
-			).put(
-				"value", layout.getFriendlyURL(defaultLocale)
-			);
+			if (!jsonObject.has("groupId")) {
+				jsonObject.put("groupId", layout.getGroupId());
+			}
+
+			if (!jsonObject.has("id")) {
+				jsonObject.put("id", layout.getUuid());
+			}
+
+			if (!jsonObject.has("name")) {
+				jsonObject.put("name", layout.getName(defaultLocale));
+			}
+
+			if (!jsonObject.has("value")) {
+				jsonObject.put("value", layout.getFriendlyURL(defaultLocale));
+			}
 
 			return jsonObject.toJSONString();
 		}


### PR DESCRIPTION
Fixes [LPS-129268](https://issues.liferay.com/browse/LPS-129268) by adding 12px right padding on the `lfr-ddm-form-pagination-controls` css class, used by the `<div>` which contains the submit button, where the visual glitch was reported.

In the case which the submit button may be required to float to the left of the div, 12px left padding was also added for consistency, since the same visual glitch occurs in that case. 

If there is such case, maybe in contexts of oriental cultures on which a left floating submit button would make more sense, the left padding applied guarantees that the visual glitch will not occur.