### PR TITLE
LPS-148802

### DIFF
--- a/tools/ant_all_benchmark.sh
+++ b/tools/ant_all_benchmark.sh
@@ -16,6 +16,8 @@ function check_performance {
 
 		if [ "${lines_count}" -ge $((${durations_min_lenght} + 1)) ]
 		then
+			remove_oldest_durations ${lines_count}
+
 			local actual_durations="$(tail -n 1 ${ANT_ALL_DURATION_CSV_PATH})"
 			local previous_durations="$(tail -n 2 ${ANT_ALL_DURATION_CSV_PATH} | head -n 1)"
 			local one_minute=60
@@ -87,6 +89,25 @@ function log_durations {
 				echo -n "," >> ${ANT_ALL_DURATION_CSV_PATH}
 			fi
 		done
+	fi
+}
+
+function remove_oldest_durations {
+	local durations_max_lenght=30
+
+	if [ "${lines_count}" -eq $((${durations_max_lenght} + 1)) ]
+	then
+		local tmp_csv_path="tools/.tmp_$(date +%s).csv"
+
+		touch ${tmp_csv_path}
+
+		head -n 1 ${ANT_ALL_DURATION_CSV_PATH} > ${tmp_csv_path}
+
+		tail -n 29 ${ANT_ALL_DURATION_CSV_PATH} >> ${tmp_csv_path}
+
+		cat ${tmp_csv_path} > ${ANT_ALL_DURATION_CSV_PATH}
+
+		rm ${tmp_csv_path}
 	fi
 }
 

--- a/tools/ant_all_benchmark.sh
+++ b/tools/ant_all_benchmark.sh
@@ -19,7 +19,7 @@ function check_performance {
 			local previous_durations="$(tail -n 2 ant_all_duration.csv | head -n 1)"
 			local one_minute=60
 
-			for (( i = 1 ; i <= 3; i++ ))
+			for (( i = 2 ; i <= 4; i++ ))
 			do
 				local actual_duration="$(echo ${actual_durations} | cut -d ',' -f ${i})"
 				local previous_duration="$(echo ${previous_durations} | cut -d ',' -f ${i})"
@@ -27,17 +27,17 @@ function check_performance {
 				if [ $(("${actual_duration}" - "${previous_duration}")) -gt "${one_minute}" ]
 				then
 
-					if [ "${i}" -eq 1 ]
+					if [ "${i}" -eq 2 ]
 					then
 						echo "Warning: performance reduced using clean repository"
 					fi
 
-					if [ "${i}" -eq 2 ]
+					if [ "${i}" -eq 3 ]
 					then
 						echo "Warning: performance reduced NOT using Gradle cache"
 					fi
 
-					if [ "${i}" -eq 3 ]
+					if [ "${i}" -eq 4 ]
 					then
 						echo "Warning: performance reduced using all caches"
 					fi
@@ -76,6 +76,7 @@ function log_durations {
 	if [ ${DURATION_LOG} == true ]
 	then
 		echo "" >> ant_all_duration.csv
+		echo -n "$(date +%c)," >> ant_all_duration.csv
 
 		for (( i = 0 ; i < ${#DURATION_ARRAY[@]}; i++ ))
 		do

--- a/tools/ant_all_benchmark.sh
+++ b/tools/ant_all_benchmark.sh
@@ -9,7 +9,7 @@ DURATION_LOG=false
 set -e
 
 function check_performance {
-	if [ ${CHECK_PERFORMANCE} == true ]
+	if [ "${CHECK_PERFORMANCE}" == true ]
 	then
 		local durations_min_lenght=2
 		local lines_count="$(($(cat ${ANT_ALL_DURATION_CSV_PATH} | wc -l) + 1))"
@@ -75,7 +75,7 @@ function enable_optional_settings {
 }
 
 function log_durations {
-	if [ ${DURATION_LOG} == true ]
+	if [ "${DURATION_LOG}" == true ]
 	then
 		echo "" >> ${ANT_ALL_DURATION_CSV_PATH}
 		echo -n "$(date +%c)," >> ${ANT_ALL_DURATION_CSV_PATH}
@@ -112,7 +112,7 @@ function remove_oldest_durations {
 }
 
 function save_duration {
-	if [ ${DURATION_LOG} == true ]
+	if [ "${DURATION_LOG}" == true ]
 	then
 		DURATION_ARRAY[${ANT_ALL_RUN_COUNT}]=${SECONDS}
 

--- a/tools/ant_all_benchmark.sh
+++ b/tools/ant_all_benchmark.sh
@@ -72,7 +72,7 @@ function main {
 
 	popd > /dev/null
 
-	git clean -dfx -e "*.${USER}.*" > /dev/null
+	git clean -dfx -e "*.${USER}.*" -e portal-ext.properties > /dev/null
 
 	rm -fr ~/.liferay
 

--- a/tools/ant_all_benchmark.sh
+++ b/tools/ant_all_benchmark.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ANT_ALL_RUN_COUNT=0
+DURATION_ARRAY=( )
 DURATION_LOG=false
 
 set -e
@@ -22,6 +24,32 @@ function enable_duration_log {
 			break
 		fi
 	done
+}
+
+function log_durations {
+	if [ ${DURATION_LOG} == true ]
+	then
+		echo "" >> ant_all_duration.csv
+
+		for (( i = 0 ; i < ${#DURATION_ARRAY[@]}; i++ ))
+		do
+			echo -n "${DURATION_ARRAY[${i}]}" >> ant_all_duration.csv
+
+			if [ "${i}" -lt "$((${#DURATION_ARRAY[@]} - 1))" ]
+			then
+				echo -n "," >> ant_all_duration.csv
+			fi
+		done
+	fi
+}
+
+function save_duration {
+	if [ ${DURATION_LOG} == true ]
+	then
+		DURATION_ARRAY[${ANT_ALL_RUN_COUNT}]=${SECONDS}
+
+		let "ANT_ALL_RUN_COUNT=${ANT_ALL_RUN_COUNT} + 1"
+	fi
 }
 
 function main {
@@ -59,15 +87,23 @@ function main {
 
 	echo "Run 1 with a clean repository $(echo_time)"
 
+	save_duration
+
 	rm -fr .gradle/caches
 
 	run_ant_all
 
 	echo "Run 2 without Gradle cache $(echo_time)"
 
+	save_duration
+
 	run_ant_all
 
 	echo "Run 3 with all caches $(echo_time)"
+
+	save_duration
+
+	log_durations
 
 	popd > /dev/null
 }

--- a/tools/ant_all_benchmark.sh
+++ b/tools/ant_all_benchmark.sh
@@ -1,10 +1,51 @@
 #!/bin/bash
 
 ANT_ALL_RUN_COUNT=0
+CHECK_PERFORMANCE=false
 DURATION_ARRAY=( )
 DURATION_LOG=false
 
 set -e
+
+function check_performance {
+	if [ ${CHECK_PERFORMANCE} == true ]
+	then
+		local durations_min_lenght=2
+		local lines_count="$(($(cat ${ANT_ALL_DURATION_CSV_PATH} | wc -l) + 1))"
+
+		if [ "${lines_count}" -ge $((${durations_min_lenght} + 1)) ]
+		then
+			local actual_durations="$(tail -n 1 ant_all_duration.csv)"
+			local previous_durations="$(tail -n 2 ant_all_duration.csv | head -n 1)"
+			local one_minute=60
+
+			for (( i = 1 ; i <= 3; i++ ))
+			do
+				local actual_duration="$(echo ${actual_durations} | cut -d ',' -f ${i})"
+				local previous_duration="$(echo ${previous_durations} | cut -d ',' -f ${i})"
+
+				if [ $(("${actual_duration}" - "${previous_duration}")) -gt "${one_minute}" ]
+				then
+
+					if [ "${i}" -eq 1 ]
+					then
+						echo "Warning: performance reduced using clean repository"
+					fi
+
+					if [ "${i}" -eq 2 ]
+					then
+						echo "Warning: performance reduced NOT using Gradle cache"
+					fi
+
+					if [ "${i}" -eq 3 ]
+					then
+						echo "Warning: performance reduced using all caches"
+					fi
+				fi
+			done
+		fi
+	fi
+}
 
 function echo_time {
 	local duration=${SECONDS}
@@ -12,16 +53,21 @@ function echo_time {
 	echo "completed in $((${duration} / 60)) minutes and $((${duration} % 60)) seconds."
 }
 
-function enable_duration_log {
+function enable_optional_settings {
 	for arg in "${@}"
 	do
+		if [ "${arg}" == "--check-performance" ]
+		then
+			CHECK_PERFORMANCE=true
+
+			echo "Performance check enabled"
+		fi
+
 		if [ "${arg}" == "--log" ]
 		then
 			DURATION_LOG=true
 
 			echo "Log to record runs duration enabled"
-
-			break
 		fi
 	done
 }
@@ -53,7 +99,7 @@ function save_duration {
 }
 
 function main {
-	enable_duration_log "${@}"
+	enable_optional_settings "${@}"
 
 	pushd .. > /dev/null
 
@@ -104,6 +150,8 @@ function main {
 	save_duration
 
 	log_durations
+
+	check_performance
 
 	popd > /dev/null
 }

--- a/tools/ant_all_benchmark.sh
+++ b/tools/ant_all_benchmark.sh
@@ -29,17 +29,17 @@ function check_performance {
 				then
 					if [ "${i}" -eq 2 ]
 					then
-						echo "Warning: performance reduced using clean repository"
+						echo "Warning: portal compile with clean repository is taking more than 1 minute than previous compile"
 					fi
 
 					if [ "${i}" -eq 3 ]
 					then
-						echo "Warning: performance reduced NOT using Gradle cache"
+						echo "Warning: portal compile without Gradle cache is taking more than 1 minute than previous compile"
 					fi
 
 					if [ "${i}" -eq 4 ]
 					then
-						echo "Warning: performance reduced using all caches"
+						echo "Warning: portal compile with all caches is taking more than 1 minute than previous compile"
 					fi
 				fi
 			done

--- a/tools/ant_all_benchmark.sh
+++ b/tools/ant_all_benchmark.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+DURATION_LOG=false
+
 set -e
 
 function echo_time {
@@ -8,7 +10,23 @@ function echo_time {
 	echo "completed in $((${duration} / 60)) minutes and $((${duration} % 60)) seconds."
 }
 
+function enable_duration_log {
+	for arg in "${@}"
+	do
+		if [ "${arg}" == "--log" ]
+		then
+			DURATION_LOG=true
+
+			echo "Log to record runs duration enabled"
+
+			break
+		fi
+	done
+}
+
 function main {
+	enable_duration_log "${@}"
+
 	pushd .. > /dev/null
 
 	local binaries_cache_dir_name=liferay-binaries-cache-2020

--- a/tools/ant_all_benchmark.sh
+++ b/tools/ant_all_benchmark.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+ANT_ALL_DURATION_CSV_PATH="tools/ant_all_duration.csv"
 ANT_ALL_RUN_COUNT=0
 CHECK_PERFORMANCE=false
 DURATION_ARRAY=( )
@@ -15,8 +16,8 @@ function check_performance {
 
 		if [ "${lines_count}" -ge $((${durations_min_lenght} + 1)) ]
 		then
-			local actual_durations="$(tail -n 1 ant_all_duration.csv)"
-			local previous_durations="$(tail -n 2 ant_all_duration.csv | head -n 1)"
+			local actual_durations="$(tail -n 1 ${ANT_ALL_DURATION_CSV_PATH})"
+			local previous_durations="$(tail -n 2 ${ANT_ALL_DURATION_CSV_PATH} | head -n 1)"
 			local one_minute=60
 
 			for (( i = 2 ; i <= 4; i++ ))
@@ -26,7 +27,6 @@ function check_performance {
 
 				if [ $(("${actual_duration}" - "${previous_duration}")) -gt "${one_minute}" ]
 				then
-
 					if [ "${i}" -eq 2 ]
 					then
 						echo "Warning: performance reduced using clean repository"
@@ -75,16 +75,16 @@ function enable_optional_settings {
 function log_durations {
 	if [ ${DURATION_LOG} == true ]
 	then
-		echo "" >> ant_all_duration.csv
-		echo -n "$(date +%c)," >> ant_all_duration.csv
+		echo "" >> ${ANT_ALL_DURATION_CSV_PATH}
+		echo -n "$(date +%c)," >> ${ANT_ALL_DURATION_CSV_PATH}
 
 		for (( i = 0 ; i < ${#DURATION_ARRAY[@]}; i++ ))
 		do
-			echo -n "${DURATION_ARRAY[${i}]}" >> ant_all_duration.csv
+			echo -n "${DURATION_ARRAY[${i}]}" >> ${ANT_ALL_DURATION_CSV_PATH}
 
 			if [ "${i}" -lt "$((${#DURATION_ARRAY[@]} - 1))" ]
 			then
-				echo -n "," >> ant_all_duration.csv
+				echo -n "," >> ${ANT_ALL_DURATION_CSV_PATH}
 			fi
 		done
 	fi

--- a/tools/ant_all_duration.csv
+++ b/tools/ant_all_duration.csv
@@ -1,1 +1,1 @@
-duration_clean_repository,duration_without_gradle_cache,duration_with_all_caches
+timestamp,duration_clean_repository,duration_without_gradle_cache,duration_with_all_caches

--- a/tools/ant_all_duration.csv
+++ b/tools/ant_all_duration.csv
@@ -1,0 +1,1 @@
+duration_clean_repository,duration_without_gradle_cache,duration_with_all_caches


### PR DESCRIPTION
Hey Brian,

I decided to suggest to you some changes in `ant_all_benchmark.sh` in order to use it to track `ant all` performance from now on. My concern is portal compile be hit again by other issue, different from the `package.json` recent problem, and we don't be warned about it. My idea is talk to Peter Yoo and suggest him to run it after each sync between your `liferay-portal` repo and the one from `liferay`. Ideally, it should be run after each merge done by you on your repo, since it'll speed up a lot the identification of commits affecting performance.

I hope you join me on this idea! :smile: We can talk more about it next week during our weekly meeting. :slightly_smiling_face: 

https://issues.liferay.com/browse/LPS-148802